### PR TITLE
More verbose description of external dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ var openapi = require("openapi-client");
 var prices = new openapi.Prices(options);
 ```
 
-### Dependencies
+### External dependencies
+The library requires below dependencies to be provided in environment where it will be used.
+
 |Dependency |Version                 |Details & URL |
 |-----------|------------------------|--------------|
 |SignalR    |2.0.3                   |Signal-R can be downloaded from https://github.com/SignalR/SignalR/releases/tag/2.0.3.|


### PR DESCRIPTION
More verbose description of external dependencies required for this library to function.
Previous description could be read as description of production content of package.json.