### PR TITLE
JSHint: Disallow console usage.

### DIFF
--- a/grunt/jshint-conf.js
+++ b/grunt/jshint-conf.js
@@ -14,7 +14,7 @@ var globalOptions = {
 	"eqnull": true,
 	"forin": true,
 	"proto": true,
-	"predef": ["fetch", "Promise", "MessageChannel", "$", "location"]
+	"predef": ["fetch", "Promise", "MessageChannel", "$", "location", "-console"]
 };
 
 var defaultTask = {

--- a/grunt/print-task.js
+++ b/grunt/print-task.js
@@ -40,12 +40,14 @@ var txt = {
 	]
 };
 
-function print(subTask) {
-	var lines = txt[subTask];
-	console.log();
-	for (var i = 0, l = lines.length; i < l; i++) {
-		console.log(lines[i]);
-	}
+function createPrint(grunt) {
+    return function (subTask) {
+        var lines = txt[subTask];
+        grunt.log.writeln();
+        for (var i = 0, l = lines.length; i < l; i++) {
+            grunt.log.writeln(lines[i]);
+        }
+    };
 }
 
-module.exports = print;
+module.exports = createPrint;

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
 
 	/* Register our own base tasks */
 
-	grunt.registerTask('print', require("./grunt/print-task"));
+	grunt.registerTask('print', require("./grunt/print-task")(grunt));
 	grunt.registerTask("force", require("./grunt/force-task")(grunt));
 	grunt.registerTask("generate-index-html", require("./grunt/generate-index-html-task")(grunt));
 	grunt.registerTask("shrinkwrap-test", require("./grunt/shrinkwrap-test-task")(grunt));


### PR DESCRIPTION
Added new jshint rule to disallow console.
Removed existing console.log usage and replaced it with grunt.log.