### PR TITLE
Add formatting scientific notation's values support

### DIFF
--- a/src/number-formatting/format.js
+++ b/src/number-formatting/format.js
@@ -12,6 +12,21 @@ function formatNegativeNumber(str, options) {
 }
 
 /**
+ * converts a number to a decimal string if it is on scientific notation
+ * @param number
+ */
+function convertNumbertToString(number, precision) {
+	let numberString = String(number);
+
+	// if the number is in scientific notation, convert to decimal
+	if(/\d+\.?\d*e[\+\-]*\d+/i.test(numberString)) {
+		numberString = number.toFixed(precision).trim('0');
+	}
+
+	return numberString;
+}
+
+/**
  * expands the number of decimals and introduces decimal groups.
  * @param number
  * @param precision
@@ -22,7 +37,7 @@ function formatNegativeNumber(str, options) {
 function expandNumber(number, precision, groupSizes, sep, decimalChar) {
 	var curSize = groupSizes[0],
 			curGroupIndex = 1,
-			numberString = String(number),
+			numberString = convertNumbertToString(number, precision),
 			decimalIndex = numberString.indexOf('.'),
 			right = "",
 			i;

--- a/test/unit/number-formatting/format-spec.js
+++ b/test/unit/number-formatting/format-spec.js
@@ -24,18 +24,22 @@ describe("NumberFormatting format", () => {
 			expect(formatNumberNoRounding(0, 4)).toEqual("0.0000");
 			expect(formatNumberNoRounding(1.1, 4)).toEqual("1.1000");
 			expect(formatNumberNoRounding(1.1212, 1)).toEqual("1.1212");
+			expect(formatNumberNoRounding(5e-7, 1)).toEqual("0.0000005");
 
 			expect(formatNumberNoRounding(-1.1212, 1)).toEqual("-1.1212");
 			expect(formatNumberNoRounding(-1.1, 4)).toEqual("-1.1000");
+			expect(formatNumberNoRounding(-5e-7, 1)).toEqual("-0.0000005");
 
 			expect(formatNumberNoRounding(0, 1, 2)).toEqual("0.0");
 			expect(formatNumberNoRounding(0, 4, 6)).toEqual("0.0000");
 			expect(formatNumberNoRounding(1.1, 4, 6)).toEqual("1.1000");
 			expect(formatNumberNoRounding(1.1212, 1, 3)).toEqual("1.121");
+			expect(formatNumberNoRounding(5e-7, 4, 8)).toEqual("0.0000005");
 
 			expect(formatNumberNoRounding(-1.1212, 1, 2)).toEqual("-1.12");
 			expect(formatNumberNoRounding(-1.126, 1, 2)).toEqual("-1.13");
 			expect(formatNumberNoRounding(-1.1, 4, 5)).toEqual("-1.1000");
+			expect(formatNumberNoRounding(-5e-7, 4, 8)).toEqual("-0.0000005");
 		});
 	});
 
@@ -70,11 +74,14 @@ describe("NumberFormatting format", () => {
 			expect(formatNumber(1.756, 2, en_us)).toEqual("1.76");
 			expect(formatNumber(1.45, 2, en_us)).toEqual("1.45");
 			expect(formatNumber(1, 2, en_us)).toEqual("1.00");
+			expect(formatNumber(5e-7, 2, en_us)).toEqual("0.00");
+			expect(formatNumber(5e-7, 7, en_us)).toEqual("0.0000005");
 
 			expect(formatNumber(545750.43, 0, en_us)).toEqual("545,750");
 			expect(formatNumber(1.756, 0, en_us)).toEqual("2");
 			expect(formatNumber(1.45, 0, en_us)).toEqual("1");
 			expect(formatNumber(1, 0, en_us)).toEqual("1");
+			expect(formatNumber(5e-7, 0, en_us)).toEqual("0");
 		});
 		it("works without decimals", () => {
 			expect(formatNumber(545750.43)).toEqual("545,750.43");
@@ -93,13 +100,16 @@ describe("NumberFormatting format", () => {
 			expect(formatNumber(-0.8, 0, en_us)).toEqual("-1");
 			expect(formatNumber(-0.5, 0, en_us)).toEqual("-1");
 			expect(formatNumber(-0.3, 0, en_us)).toEqual("0");
+			expect(formatNumber(-5e-7, 0, en_us)).toEqual("0");
 			expect(formatNumber(0, 0, en_us)).toEqual("0");
 			expect(formatNumber(-0, 0, en_us)).toEqual("0");
+			expect(formatNumber(5e-7, 0, en_us)).toEqual("0");
 			expect(formatNumber(0.3, 0, en_us)).toEqual("0");
 			expect(formatNumber(0.5, 0, en_us)).toEqual("1");
 			expect(formatNumber(0.8, 0, en_us)).toEqual("1");
 			expect(formatNumber(1.2, 0, en_us)).toEqual("1");
 			expect(formatNumber(1.5, 0, en_us)).toEqual("2");
+
 
 			expect(formatNumber(-1.15, 1, en_us)).toEqual("-1.2");
 			expect(formatNumber(-1.13, 1, en_us)).toEqual("-1.1");
@@ -109,6 +119,8 @@ describe("NumberFormatting format", () => {
 			expect(formatNumber(1.13, 1, en_us)).toEqual("1.1");
 			expect(formatNumber(0.05, 1, en_us)).toEqual("0.1");
 			expect(formatNumber(0.01, 1, en_us)).toEqual("0.0");
+			expect(formatNumber(5e-7, 6, en_us)).toEqual("0.000001");
+			expect(formatNumber(-5e-7, 6, en_us)).toEqual("-0.000001");
 		});
 	});
 });

--- a/test/unit/price-formatting/format-spec.js
+++ b/test/unit/price-formatting/format-spec.js
@@ -35,6 +35,9 @@ describe("price-formatting format", () => {
 		expect(priceFormatting.format(1234567.23451, 4)).toEqual("1,234,567.2345");
 		expect(priceFormatting.format(-1234567.23451, 4)).toEqual("-1,234,567.2345");
 
+		expect(priceFormatting.format(5e-7, 7)).toEqual("0.0000005");
+		expect(priceFormatting.format(5.23e-7, 9)).toEqual("0.000000523");
+
 		expect(priceFormatting.format(42, 4, priceFormatOptions.Fractions)).toEqual("42");
 
 		expect(priceFormatting.format(42.0625, 4, priceFormatOptions.Fractions)).toEqual("42\u00a01/16");


### PR DESCRIPTION
Adds the possibility to format values on scientific notation.

A value such as `0.0000005` is automatically converted to `5e-7` on javascript. Number format would then pick convert the value to a string and the output would be something completely wrong - i.e `5,e-7`.

This fix parses the scientific notation value and adds the correct amount of zeros to then allow the formatter to do his normal steps.