### PR TITLE
Clear reconnect timeout 

### DIFF
--- a/src/openapi/streaming/streaming.js
+++ b/src/openapi/streaming/streaming.js
@@ -32,12 +32,13 @@ const ignoreSubscriptions = {};
  * then follows the SignalR state model.
  */
 function init() {
-
+    clearReconnect.call(this);
     setNewContextId.call(this);
 
     const connection = $.connection(this.connectionUrl);
     connection.log = onSignalRLog;
     this.connection = connection;
+    this.reconnecting = false;
     updateConnectionQuery.call(this);
 
     connection.stateChanged(onConnectionStateChanged.bind(this));
@@ -84,10 +85,21 @@ function setNewContextId() {
 }
 
 /**
+ * Clear existing reconnect timeout
+ */
+function clearReconnect() {
+    if (this.reconnectTimeout) {
+        clearTimeout(this.reconnectTimeout);
+        this.reconnectTimeout = null;
+    }
+}
+
+/**
  * Retries the connection after a time
  */
 function retryConnection() {
-    setTimeout(reconnect.bind(this), this.retryDelay);
+    clearReconnect.call(this);
+    this.reconnectTimeout = setTimeout(reconnect.bind(this), this.retryDelay);
 }
 
 /**
@@ -159,6 +171,7 @@ function onConnectionStateChanged(change) {
             // if *we* are reconnecting (as opposed to signal-r reconnecting, which we do not need to handle specially)
             if (this.reconnecting) {
                 resetAllSubscriptions.call(this);
+                clearReconnect.call(this);
                 this.reconnecting = false;
             }
 


### PR DESCRIPTION
Clearing reconnect timeout upon connection and multiple consecutive reconnects.

Currently, reconnect timeouts are left hanging after they are fired. In some scenarios this can cause unnecessary firing of reconnects logic.