### PR TITLE
allow fetch to handle binary responses when content-type is a pdf or an excel sheet

### DIFF
--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -9,6 +9,12 @@ import log from '../log';
 
 const LOG_AREA = 'Fetch';
 
+const binaryContentTypes = {
+    'application/pdf': true,
+    'application/vnd.ms-excel': true,
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': true,
+};
+
 /**
  * Follows the jQuery way of cache breaking - start with the current time and add 1 per request,
  * meaning you would have to do more than 1000 per second
@@ -106,7 +112,7 @@ function convertFetchResponse(url, body, result, isRejected) {
                 url,
             };
         });
-    } else if (contentType && contentType.indexOf('application/') > -1) {
+    } else if (contentType && binaryContentTypes[contentType] > -1) {
         convertedPromise = result.blob().then(function(blob) {
             return {
                 response: blob,

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -106,6 +106,16 @@ function convertFetchResponse(url, body, result, isRejected) {
                 url,
             };
         });
+    } else if (contentType && contentType.indexOf('application/') > -1) {
+        convertedPromise = result.blob().then(function(blob) {
+            return {
+                response: blob,
+                status: result.status,
+                headers: result.headers,
+                size: blob.size,
+                url,
+            };
+        });
     } else {
         convertedPromise = result.text().then(function(text) {
             return {

--- a/test/unit/mocks/fetch.js
+++ b/test/unit/mocks/fetch.js
@@ -1,6 +1,6 @@
 ﻿import { global } from '../utils';
 
-function FetchResponse(status, response, contentType) {
+export function FetchResponse(status, response, contentType) {
     this.status = status;
     this.response = response;
 
@@ -24,6 +24,12 @@ function FetchResponse(status, response, contentType) {
             } else {
                 resolve(response);
             }
+        });
+    };
+
+    this.blob = function() {
+        return new Promise(function(resolve) {
+            resolve(response);
         });
     };
 }

--- a/test/unit/utils/fetch-spec.js
+++ b/test/unit/utils/fetch-spec.js
@@ -1,3 +1,4 @@
+// tests for saxo.utils.fetch.convertFetchResponse
 import { convertFetchResponse } from '../../../src/utils/fetch';
 import { FetchResponse } from '../mocks/fetch';
 

--- a/test/unit/utils/fetch-spec.js
+++ b/test/unit/utils/fetch-spec.js
@@ -1,0 +1,74 @@
+import { convertFetchResponse } from '../../../src/utils/fetch';
+import { FetchResponse } from '../mocks/fetch';
+
+describe('utils fetch', () => {
+    it('images are downloaded as a binary blob', (done) => {
+        const contentType = 'image/jpeg';
+        const result = new FetchResponse(200, 'this is a binary image', contentType);
+        const promise = convertFetchResponse('url', 'body', result);
+
+        promise.then((response) => {
+            expect(response.response).toEqual('this is a binary image');
+            expect(response.status).toEqual(200);
+            expect(response.headers.get('content-type')).toEqual(contentType);
+            expect(response.responseType).toEqual('blob');
+            done();
+        });
+
+        Promise.resolve(promise);
+    });
+
+    it('json is downloaded and converted to an object', (done) => {
+        const contentType = 'application/json';
+        const result = new FetchResponse(200, '{"test":1}', contentType);
+        const promise = convertFetchResponse('url', 'body', result);
+
+        promise.then((response) => {
+            expect(response.response).toEqual({ test: 1 });
+            expect(response.status).toEqual(200);
+            expect(response.headers.get('content-type')).toEqual(contentType);
+            expect(response.responseType).toEqual('json');
+            done();
+        });
+
+        Promise.resolve(promise);
+    });
+
+    it('xslx is downloaded as a binary blob', (done) => {
+        const contentType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+        const result = new FetchResponse(200, 'this is a binary string', contentType);
+        const promise = convertFetchResponse('url', 'body', result);
+
+        promise.then((response) => {
+            expect(response.response).toEqual('this is a binary string');
+            expect(response.status).toEqual(200);
+            expect(response.headers.get('content-type')).toEqual(contentType);
+            expect(response.responseType).toEqual('blob');
+            done();
+        });
+
+        Promise.resolve(promise);
+    });
+
+    it('unknown file types are downloaded as text', (done) => {
+        const contentType = 'unknown/file';
+        const result = new FetchResponse(200, 'this is a string', contentType);
+        const promise = convertFetchResponse('url', 'body', result);
+
+        promise.then((response) => {
+            expect(response.response).toEqual('this is a string');
+            expect(response.status).toEqual(200);
+            expect(response.headers.get('content-type')).toEqual(contentType);
+            expect(response.responseType).toEqual('text');
+            done();
+        });
+
+        Promise.resolve(promise);
+    });
+
+    it('empty responses throw an error', () => {
+        expect(() => {
+            convertFetchResponse('url', 'body', null);
+        }).toThrow();
+    });
+});


### PR DESCRIPTION
This will allow fetch to handle binary responses when content-type is a pdf or an excel sheet.