### PR TITLE
Add support for decimal values to NumberFormatting.shortFormat

### DIFF
--- a/src/number-formatting/short-format.js
+++ b/src/number-formatting/short-format.js
@@ -18,23 +18,23 @@ import formatNumber from './format';
  * @returns {string} Returns 0 when dates are equal. -1 when date1 less than date2. 1 when date1 greater than date2.
  */
 function shortFormat(num, options) {
-
-    let numberSize = String(num).length; // Unfortunately Logs are too inaccurate - Math.round(Math.log(num) / Math.LN10)
+    const [digits] = String(num).split('.');
+    let digitSize = digits.length;
     let boundary;
 
-    if (numberSize >= 5) { // bigger than 10,000
-        boundary = Math.pow(10, numberSize) - (Math.pow(10, numberSize - 3) / 2); // e.g. 100,000 -> 9,9950 - closer to 100k than 99.9k
+    if (digitSize >= 5) { // bigger than 10,000
+        boundary = Math.pow(10, digitSize) - (Math.pow(10, digitSize - 3) / 2); // e.g. 100,000 -> 9,9950 - closer to 100k than 99.9k
         if (num >= boundary) {
-            numberSize++;
+            digitSize++;
         }
     }
 
-    if (numberSize >= 7) { // > 999500
-        return formatNumber(num / 1000000, 2 - (numberSize - 7), options) + 'm';
+    if (digitSize >= 7) { // > 999500
+        return formatNumber(num / 1000000, 2 - (digitSize - 7), options) + 'm';
     }
 
-    if (numberSize >= 5) { // > 9995 => 10.2k
-        return formatNumber(num / 1000, 2 - (numberSize - 4), options) + 'k';
+    if (digitSize >= 5) { // > 9995 => 10.2k
+        return formatNumber(num / 1000, 2 - (digitSize - 4), options) + 'k';
     }
 
     return formatNumber(num, 0, options);

--- a/test/unit/number-formatting/format-spec.js
+++ b/test/unit/number-formatting/format-spec.js
@@ -45,7 +45,6 @@ describe('NumberFormatting format', () => {
 
     describe('short format', () => {
         it('basically works', () => {
-            expect(shortFormat(1.45)).toEqual('1');
             expect(shortFormat(1000)).toEqual('1,000');
             expect(shortFormat(9999)).toEqual('9,999');
             expect(shortFormat(10000)).toEqual('10.0k');
@@ -56,7 +55,6 @@ describe('NumberFormatting format', () => {
             expect(shortFormat(20049)).toEqual('20.0k');
             expect(shortFormat(99949)).toEqual('99.9k');
             expect(shortFormat(99950)).toEqual('100k');
-
             expect(shortFormat(999499)).toEqual('999k');
             expect(shortFormat(999500)).toEqual('1.00m');
             expect(shortFormat(1000000)).toEqual('1.00m');
@@ -65,6 +63,16 @@ describe('NumberFormatting format', () => {
             expect(shortFormat(10500000)).toEqual('10.5m');
             expect(shortFormat(105000000)).toEqual('105m');
             expect(shortFormat(1050000000)).toEqual('1,050m');
+        });
+
+        it('works with decimals', () => {
+            expect(shortFormat(1.45)).toEqual('1');
+            expect(shortFormat(99.4)).toEqual('99');
+            expect(shortFormat(99.5)).toEqual('100');
+            expect(shortFormat(100.11)).toEqual('100');
+            expect(shortFormat(1000.11)).toEqual('1,000');
+            expect(shortFormat(99949.11)).toEqual('99.9k');
+            expect(shortFormat(100000000.11)).toEqual('100m');
         });
     });
 


### PR DESCRIPTION
NumberFormatting.shortFormat didn't support decimals properly. Specifically, some floating points gave issues such as 1000000.11 => 0m. This fixes the issue by calculating the boundary from digit size.

Fixes #48 