### PR TITLE
 Add precision parameter to short formatter

### DIFF
--- a/src/number-formatting/number-formatting.js
+++ b/src/number-formatting/number-formatting.js
@@ -90,8 +90,8 @@ NumberFormatting.prototype.formatNoRounding = function(num, minDecimals, maxDeci
  * @param {number} number
  * @returns {string}
  */
-NumberFormatting.prototype.shortFormat = function(number) {
-    return shortFormat(number, this);
+NumberFormatting.prototype.shortFormat = function(number, precision) {
+    return shortFormat(number, precision, this);
 };
 
 /**

--- a/src/number-formatting/number-formatting.js
+++ b/src/number-formatting/number-formatting.js
@@ -88,6 +88,7 @@ NumberFormatting.prototype.formatNoRounding = function(num, minDecimals, maxDeci
 /**
  * Formats a number into a short format, e.g. 10.000 becomes 10k.
  * @param {number} number
+ * @param {number} precision
  * @returns {string}
  */
 NumberFormatting.prototype.shortFormat = function(number, precision) {

--- a/src/number-formatting/short-format.js
+++ b/src/number-formatting/short-format.js
@@ -17,7 +17,7 @@ import formatNumber from './format';
  * @param options
  * @returns {string} Returns 0 when dates are equal. -1 when date1 less than date2. 1 when date1 greater than date2.
  */
-function shortFormat(num, options) {
+function shortFormat(num, precision, options) {
     const [digits] = String(num).split('.');
     let digitSize = digits.length;
     let boundary;
@@ -30,11 +30,13 @@ function shortFormat(num, options) {
     }
 
     if (digitSize >= 7) { // > 999500
-        return formatNumber(num / 1000000, 2 - (digitSize - 7), options) + 'm';
+        const digitPrecision = !isNaN(precision) ? precision : (2 - (digitSize - 7));
+        return formatNumber(num / 1000000, digitPrecision, options) + 'm';
     }
 
     if (digitSize >= 5) { // > 9995 => 10.2k
-        return formatNumber(num / 1000, 2 - (digitSize - 4), options) + 'k';
+        const digitPrecision = !isNaN(precision) ? precision : (2 - (digitSize - 4));
+        return formatNumber(num / 1000, digitPrecision, options) + 'k';
     }
 
     return formatNumber(num, 0, options);

--- a/src/number-formatting/short-format.js
+++ b/src/number-formatting/short-format.js
@@ -14,6 +14,7 @@ import formatNumber from './format';
 /**
  * Converts from a number to a string like "1k" or "100m".
  * @param num
+ * @param precision
  * @param options
  * @returns {string} Returns 0 when dates are equal. -1 when date1 less than date2. 1 when date1 greater than date2.
  */
@@ -30,13 +31,13 @@ function shortFormat(num, precision, options) {
     }
 
     if (digitSize >= 7) { // > 999500
-        const digitPrecision = !isNaN(precision) ? precision : (2 - (digitSize - 7));
-        return formatNumber(num / 1000000, digitPrecision, options) + 'm';
+        const numberPrecision = !isNaN(precision) ? precision : (2 - (digitSize - 7));
+        return formatNumber(num / 1000000, numberPrecision, options) + 'm';
     }
 
     if (digitSize >= 5) { // > 9995 => 10.2k
-        const digitPrecision = !isNaN(precision) ? precision : (2 - (digitSize - 4));
-        return formatNumber(num / 1000, digitPrecision, options) + 'k';
+        const numberPrecision = !isNaN(precision) ? precision : (2 - (digitSize - 4));
+        return formatNumber(num / 1000, numberPrecision, options) + 'k';
     }
 
     return formatNumber(num, 0, options);

--- a/src/number-formatting/short-format.js
+++ b/src/number-formatting/short-format.js
@@ -40,7 +40,8 @@ function shortFormat(num, precision, options) {
         return formatNumber(num / 1000, numberPrecision, options) + 'k';
     }
 
-    return formatNumber(num, 0, options);
+    const numberPrecision = !isNaN(precision) ? precision : 0;
+    return formatNumber(num, numberPrecision, options);
 }
 
 // -- Export section --

--- a/test/unit/number-formatting/format-spec.js
+++ b/test/unit/number-formatting/format-spec.js
@@ -7,9 +7,9 @@ function formatNumberNoRounding(number, minDecimals, maxDecimals) {
     return numbers.formatNoRounding(number, minDecimals, maxDecimals);
 }
 
-function shortFormat(number) {
+function shortFormat(number, precision) {
     const numbers = new NumberFormatting();
-    return numbers.shortFormat(number);
+    return numbers.shortFormat(number, precision);
 }
 
 function formatNumber(number, decimals, options) {
@@ -73,6 +73,23 @@ describe('NumberFormatting format', () => {
             expect(shortFormat(1000.11)).toEqual('1,000');
             expect(shortFormat(99949.11)).toEqual('99.9k');
             expect(shortFormat(100000000.11)).toEqual('100m');
+        });
+
+        it('works with customized precision', () => {
+            expect(shortFormat(1000.55, 0)).toEqual('1,001');
+            expect(shortFormat(1000, 0)).toEqual('1,000');
+            expect(shortFormat(1000, 2)).toEqual('1,000.00');
+            expect(shortFormat(50000, 0)).toEqual('50k');
+            expect(shortFormat(50000, 1)).toEqual('50.0k');
+            expect(shortFormat(999499, 0)).toEqual('999k');
+            expect(shortFormat(999499, 1)).toEqual('999.5k');
+            expect(shortFormat(999500, 0)).toEqual('1m');
+            expect(shortFormat(999500, 3)).toEqual('1.000m');
+            expect(shortFormat(10490000, 0)).toEqual('10m');
+            expect(shortFormat(10500000, 0)).toEqual('11m');
+            expect(shortFormat(10500000, 1)).toEqual('10.5m');
+            expect(shortFormat(105000000, 0)).toEqual('105m');
+            expect(shortFormat(1050000000, 2)).toEqual('1,050.00m');
         });
     });
 


### PR DESCRIPTION
Add precision parameter to short formatter

In some cases, short formatted numbers require custom precision. Developers should be able to define, with what precision shortened number should be returned.

The new signature of `shortFormat ` should be compatible with previous usages. To guarantee that a check for the presence of `precision` parameter is done. If the parameter is not present, the function will calculate the precision in the old way.