### PR TITLE
adding check for negative zero in case of formatting infinitesimally small negative values

### DIFF
--- a/src/price-formatting/format.js
+++ b/src/price-formatting/format.js
@@ -198,8 +198,11 @@ function formatPriceParts(numberFormatting, value, decimals, formatFlags, numera
     }
 
     if (isNegative) {
-        parts.Post = numberFormatting.negativePost;
-        parts.Pre = numberFormatting.negativePre;
+
+        // Infinitesimally small negative value is rounded to 0 in which case Pre/Post (for some languages) should not be '-',
+        // as '-0'/'0-' makes no sense, hence the below check.
+        parts.Post = (parts.First === '0' && !parts.Pips && !parts.DeciPips) ? '' : numberFormatting.negativePost;
+        parts.Pre = (parts.First === '0' && !parts.Pips && !parts.DeciPips) ? '' : numberFormatting.negativePre;
     }
 
     return parts;

--- a/test/unit/price-formatting/format-spec.js
+++ b/test/unit/price-formatting/format-spec.js
@@ -660,6 +660,22 @@ describe('price-formatting format', () => {
         expect(parts.Pips).toEqual(_multiply('\u00a0', 8));
         expect(parts.DeciPips).toEqual('');
         expect(parts.Post).toEqual('');
+
+        // Infinitesimally small negative value check for left to right indented languages, ex: english.
+        parts = priceFormatting.formatPriceParts(-0.00972999999999047, 5, priceFormatOptions.Fractions);
+        expect(parts.Pre).toEqual('');
+        expect(parts.First).toEqual('0');
+        expect(parts.Pips).toEqual('');
+        expect(parts.DeciPips).toEqual('');
+        expect(parts.Post).toEqual('');
+
+        // Infinitesimally small negative value check for right to left indented languages, ex: arabic.
+        parts = priceFormatting_ar_eg.formatPriceParts(-0.00972999999999047, 5, priceFormatOptions.Fractions);
+        expect(parts.Pre).toEqual('');
+        expect(parts.First).toEqual('0');
+        expect(parts.Pips).toEqual('');
+        expect(parts.DeciPips).toEqual('');
+        expect(parts.Post).toEqual('');
     });
 
     it('handles non numbers', () => {


### PR DESCRIPTION
issue: #59  Infinitesimally small negative value is rounded to 0 and the value returned is -0 or 0-, which is unexpected
Fix: if the format value is zero removing the '-' sign 