### PR TITLE
Short formatter remove 'zero tails' by default

### DIFF
--- a/src/number-formatting/format.js
+++ b/src/number-formatting/format.js
@@ -30,10 +30,10 @@ function convertNumbertToString(number, precision) {
  * expands the number of decimals and introduces decimal groups.
  * @param number
  * @param precision
- * @param { groupSizes, sep, decimalChar, isHideZeroTail } options
+ * @param { groupSizes, groupSeparator, decimalSeparator, isHideZeroTail } options
  */
 function expandNumber(number, precision, options) {
-    const { groupSizes, sep, decimalChar, isHideZeroTail } = options;
+    const { groupSizes, groupSeparator, decimalSeparator, isHideZeroTail } = options;
     let curSize = groupSizes[0];
     let curGroupIndex = 1;
     let numberString = convertNumbertToString(number, precision);
@@ -60,7 +60,7 @@ function expandNumber(number, precision, options) {
             }
         }
 
-        right = decimalChar + right;
+        right = decimalSeparator + right;
     } else {
         right = '';
     }
@@ -70,14 +70,14 @@ function expandNumber(number, precision, options) {
     while (stringIndex >= 0) {
         if (curSize === 0 || curSize > stringIndex) {
             if (ret.length > 0) {
-                return numberString.slice(0, stringIndex + 1) + sep + ret + right;
+                return numberString.slice(0, stringIndex + 1) + groupSeparator + ret + right;
             }
 
             return numberString.slice(0, stringIndex + 1) + right;
         }
 
         if (ret.length > 0) {
-            ret = numberString.slice(stringIndex - curSize + 1, stringIndex + 1) + sep + ret;
+            ret = numberString.slice(stringIndex - curSize + 1, stringIndex + 1) + groupSeparator + ret;
         } else {
             ret = numberString.slice(stringIndex - curSize + 1, stringIndex + 1);
         }
@@ -89,7 +89,7 @@ function expandNumber(number, precision, options) {
             curGroupIndex++;
         }
     }
-    return numberString.slice(0, stringIndex + 1) + sep + ret + right;
+    return numberString.slice(0, stringIndex + 1) + groupSeparator + ret + right;
 }
 
 // -- Exported methods section --
@@ -106,14 +106,7 @@ function formatNumber(inputNumber, decimals, options) {
     let absoluteNumber = Math.abs(inputNumber);
     absoluteNumber = Math.round(absoluteNumber * factor) / factor;
 
-    const opts = {
-        groupSizes: options.groupSizes,
-        sep: options.groupSeparator,
-        decimalChar: options.decimalSeparator,
-        isHideZeroTail: options.isHideZeroTail,
-    };
-
-    let formattedNumber = expandNumber(Math.abs(absoluteNumber), decimals, opts);
+    let formattedNumber = expandNumber(Math.abs(absoluteNumber), decimals, options);
 
     // if the original is negative and it hasn't been rounded to 0
     if (inputNumber < 0 && absoluteNumber !== 0) {

--- a/src/number-formatting/format.js
+++ b/src/number-formatting/format.js
@@ -30,11 +30,10 @@ function convertNumbertToString(number, precision) {
  * expands the number of decimals and introduces decimal groups.
  * @param number
  * @param precision
- * @param groupSizes
- * @param sep
- * @param decimalChar
+ * @param { groupSizes, sep, decimalChar, isHideZeroTail } options
  */
-function expandNumber(number, precision, groupSizes, sep, decimalChar) {
+function expandNumber(number, precision, options) {
+    const { groupSizes, sep, decimalChar, isHideZeroTail } = options;
     let curSize = groupSizes[0];
     let curGroupIndex = 1;
     let numberString = convertNumbertToString(number, precision);
@@ -47,7 +46,10 @@ function expandNumber(number, precision, groupSizes, sep, decimalChar) {
         numberString = numberString.slice(0, decimalIndex);
     }
 
-    if (precision > 0) {
+    const isTailOnlyZeroDigit = Number(right) === 0;
+    const isAllowZeroTail = !(isHideZeroTail && isTailOnlyZeroDigit);
+
+    if (precision > 0 && isAllowZeroTail) {
         const rightDifference = right.length - precision;
         if (rightDifference > 0) {
             right = right.slice(0, precision);
@@ -105,10 +107,12 @@ function formatNumber(inputNumber, decimals, options) {
     absoluteNumber = Math.round(absoluteNumber * factor) / factor;
 
     let formattedNumber = expandNumber(Math.abs(absoluteNumber),
-                                decimals,
-                                options.groupSizes,
-                                options.groupSeparator,
-                                options.decimalSeparator);
+                                decimals, {
+                                    groupSizes: options.groupSizes,
+                                    sep: options.groupSeparator,
+                                    decimalChar: options.decimalSeparator,
+                                    isHideZeroTail: options.isHideZeroTail,
+                                });
 
     // if the original is negative and it hasn't been rounded to 0
     if (inputNumber < 0 && absoluteNumber !== 0) {

--- a/src/number-formatting/format.js
+++ b/src/number-formatting/format.js
@@ -106,13 +106,14 @@ function formatNumber(inputNumber, decimals, options) {
     let absoluteNumber = Math.abs(inputNumber);
     absoluteNumber = Math.round(absoluteNumber * factor) / factor;
 
-    let formattedNumber = expandNumber(Math.abs(absoluteNumber),
-                                decimals, {
-                                    groupSizes: options.groupSizes,
-                                    sep: options.groupSeparator,
-                                    decimalChar: options.decimalSeparator,
-                                    isHideZeroTail: options.isHideZeroTail,
-                                });
+    const opts = {
+        groupSizes: options.groupSizes,
+        sep: options.groupSeparator,
+        decimalChar: options.decimalSeparator,
+        isHideZeroTail: options.isHideZeroTail,
+    };
+
+    let formattedNumber = expandNumber(Math.abs(absoluteNumber), decimals, opts);
 
     // if the original is negative and it hasn't been rounded to 0
     if (inputNumber < 0 && absoluteNumber !== 0) {

--- a/src/number-formatting/number-formatting.js
+++ b/src/number-formatting/number-formatting.js
@@ -88,11 +88,10 @@ NumberFormatting.prototype.formatNoRounding = function(num, minDecimals, maxDeci
 /**
  * Formats a number into a short format, e.g. 10.000 becomes 10k.
  * @param {number} number
- * @param {number} precision
  * @returns {string}
  */
-NumberFormatting.prototype.shortFormat = function(number, precision) {
-    return shortFormat(number, precision, this);
+NumberFormatting.prototype.shortFormat = function(number) {
+    return shortFormat(number, this);
 };
 
 /**

--- a/src/number-formatting/short-format.js
+++ b/src/number-formatting/short-format.js
@@ -3,6 +3,7 @@
  * @ignore
  */
 
+import { extend } from '../utils/object';
 import formatNumber from './format';
 
 // -- Local variables section --
@@ -19,7 +20,7 @@ import formatNumber from './format';
  * @returns {string} Returns 0 when dates are equal. -1 when date1 less than date2. 1 when date1 greater than date2.
  */
 function shortFormat(num, options) {
-    const shortFormatOptions = $.extend({}, options, { isHideZeroTail: true });
+    const shortFormatOptions = extend({}, options, { isHideZeroTail: true });
     const [digits] = String(num).split('.');
     let digitSize = digits.length;
     let boundary;

--- a/src/number-formatting/short-format.js
+++ b/src/number-formatting/short-format.js
@@ -18,7 +18,8 @@ import formatNumber from './format';
  * @param options
  * @returns {string} Returns 0 when dates are equal. -1 when date1 less than date2. 1 when date1 greater than date2.
  */
-function shortFormat(num, precision, options) {
+function shortFormat(num, options) {
+    const shortFormatOptions = $.extend({}, options, { isHideZeroTail: true });
     const [digits] = String(num).split('.');
     let digitSize = digits.length;
     let boundary;
@@ -31,17 +32,17 @@ function shortFormat(num, precision, options) {
     }
 
     if (digitSize >= 7) { // > 999500
-        const numberPrecision = !isNaN(precision) ? precision : (2 - (digitSize - 7));
-        return formatNumber(num / 1000000, numberPrecision, options) + 'm';
+        const numberPrecision = (2 - (digitSize - 7));
+        return formatNumber(num / 1000000, numberPrecision, shortFormatOptions) + 'm';
     }
 
     if (digitSize >= 5) { // > 9995 => 10.2k
-        const numberPrecision = !isNaN(precision) ? precision : (2 - (digitSize - 4));
-        return formatNumber(num / 1000, numberPrecision, options) + 'k';
+        const numberPrecision = (2 - (digitSize - 4));
+        return formatNumber(num / 1000, numberPrecision, shortFormatOptions) + 'k';
     }
 
-    const numberPrecision = !isNaN(precision) ? precision : 0;
-    return formatNumber(num, numberPrecision, options);
+    const numberPrecision = 0;
+    return formatNumber(num, numberPrecision, shortFormatOptions);
 }
 
 // -- Export section --

--- a/test/unit/number-formatting/format-spec.js
+++ b/test/unit/number-formatting/format-spec.js
@@ -47,18 +47,18 @@ describe('NumberFormatting format', () => {
         it('basically works', () => {
             expect(shortFormat(1000)).toEqual('1,000');
             expect(shortFormat(9999)).toEqual('9,999');
-            expect(shortFormat(10000)).toEqual('10.0k');
-            expect(shortFormat(10049)).toEqual('10.0k');
+            expect(shortFormat(10000)).toEqual('10k');
+            expect(shortFormat(10049)).toEqual('10k');
             expect(shortFormat(10050)).toEqual('10.1k');
             expect(shortFormat(10940)).toEqual('10.9k');
-            expect(shortFormat(19950)).toEqual('20.0k');
-            expect(shortFormat(20049)).toEqual('20.0k');
+            expect(shortFormat(19950)).toEqual('20k');
+            expect(shortFormat(20049)).toEqual('20k');
             expect(shortFormat(99949)).toEqual('99.9k');
             expect(shortFormat(99950)).toEqual('100k');
             expect(shortFormat(999499)).toEqual('999k');
-            expect(shortFormat(999500)).toEqual('1.00m');
-            expect(shortFormat(1000000)).toEqual('1.00m');
-            expect(shortFormat(1000100)).toEqual('1.00m');
+            expect(shortFormat(999500)).toEqual('1m');
+            expect(shortFormat(1000000)).toEqual('1m');
+            expect(shortFormat(1000100)).toEqual('1m');
             expect(shortFormat(1050000)).toEqual('1.05m');
             expect(shortFormat(10500000)).toEqual('10.5m');
             expect(shortFormat(105000000)).toEqual('105m');
@@ -73,23 +73,6 @@ describe('NumberFormatting format', () => {
             expect(shortFormat(1000.11)).toEqual('1,000');
             expect(shortFormat(99949.11)).toEqual('99.9k');
             expect(shortFormat(100000000.11)).toEqual('100m');
-        });
-
-        it('works with customized precision', () => {
-            expect(shortFormat(1000.55, 0)).toEqual('1,001');
-            expect(shortFormat(1000, 0)).toEqual('1,000');
-            expect(shortFormat(1000, 2)).toEqual('1,000.00');
-            expect(shortFormat(50000, 0)).toEqual('50k');
-            expect(shortFormat(50000, 1)).toEqual('50.0k');
-            expect(shortFormat(999499, 0)).toEqual('999k');
-            expect(shortFormat(999499, 1)).toEqual('999.5k');
-            expect(shortFormat(999500, 0)).toEqual('1m');
-            expect(shortFormat(999500, 3)).toEqual('1.000m');
-            expect(shortFormat(10490000, 0)).toEqual('10m');
-            expect(shortFormat(10500000, 0)).toEqual('11m');
-            expect(shortFormat(10500000, 1)).toEqual('10.5m');
-            expect(shortFormat(105000000, 0)).toEqual('105m');
-            expect(shortFormat(1050000000, 2)).toEqual('1,050.00m');
         });
     });
 


### PR DESCRIPTION
Short formatter remove 'zero tails' by default

Short formatter should not allow manually set precision for formatted numbers but when shortened number has tail only from `0` digits (ex. `10.00k` / `50.0k` etc.) it should be removed (`10.00k` into `10k` / `50.0k` into `50k`).

The `expandNumber` function has a new option flag, which is turned on by default for `shortFormat` function (we want to keep the result of the short format as short as possible). This flag prevents displaying of the floating part (only when made of `0` digits) and unnecessary related calculations.