### PR TITLE
Improve logging and refresh retrying logic in case of network errors

### DIFF
--- a/src/openapi/transport/auth.js
+++ b/src/openapi/transport/auth.js
@@ -80,12 +80,18 @@ function onApiTokenReceived(result) {
 function onApiTokenReceiveFail(result) {
     this.state = STATE_WAITING;
     log.warn(LOG_AREA, 'Token refresh failed', result);
-    this.trigger(this.EVENT_TOKEN_REFRESH_FAILED);
+
+    if (result && (result.status === 401 || result.status === 403)) {
+        this.trigger(this.EVENT_TOKEN_REFRESH_FAILED);
+        return;
+    }
 
     if (this.retries < this.maxRetryCount) {
         this.retries++;
         this.tokenRefreshTimerFireTime = Date.now() + this.retryDelayMs;
         this.tokenRefreshTimer = setTimeout(this.refreshOpenApiToken.bind(this), this.retryDelayMs);
+    } else {
+        this.trigger(this.EVENT_TOKEN_REFRESH_FAILED);
     }
 }
 

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -29,47 +29,40 @@ let cacheBreakNum = Date.now();
  * Returns a rejected promise, needed to keep the promise rejected.
  * @param result
  */
-function convertFetchReject(url, body, result) {
-    return convertFetchResponse(url, body, result, true);
+function convertFetchReject(url, body, error) {
+    log.error(LOG_AREA, 'rejected non-response', {
+        url,
+        body,
+        error,
+    });
+
+    const networkError = {
+        message: error && error.message ? error.message : error,
+        isNetworkError: true,
+    };
+
+    throw networkError;
 }
 
 /**
- * Converts the fetch response and returns either a resolved or rejected Promise.
- * @param result
- */
-function convertFetchSuccess(url, body, result) {
-    // See also the same logic applied to the batch response
-    if ((result.status < 200 || result.status > 299) && result.status !== 304) {
-        return convertFetchResponse(url, body, result, true);
-    }
-    return convertFetchResponse(url, body, result);
-}
-
-/**
- * Parses the json or gets the text from the response as required.
+ * Returns either a resolved or rejected Promise.
+ * If resolved, parses the json or gets the text from the response as required.
  * @param result
  * @returns {Promise}
  */
-export function convertFetchResponse(url, body, result, isRejected) {
-
-    // if this ia an exception rather than a result, reject immediately without
-    // trying to parse
-    if (!result || !result.status || !result.headers) {
-        log.error(LOG_AREA, 'rejected non-response', {
+export function convertFetchSuccess(url, body, result) {
+    let convertedPromise;
+    if ((result.status < 200 || result.status > 299) && result.status !== 304) {
+        log.error(LOG_AREA, 'rejected server response', {
             url,
             body,
-            error: result,  // "error" is processed by the logger in a special way
+            status: result.status,
+            response: result.response,
         });
 
-        const networkError = {
-            message: result && result.message ? result.message : result,
-            isNetworkError: true,
-        };
-
-        throw networkError;
+        throw result;
     }
     const contentType = result.headers.get('content-type');
-    let convertedPromise;
     if (contentType && contentType.indexOf('application/json') > -1) {
         convertedPromise = result.text()
             .then(function(text) {
@@ -143,20 +136,6 @@ export function convertFetchResponse(url, body, result, isRejected) {
             };
         });
     }
-
-    if (isRejected) {
-        convertedPromise = convertedPromise.then((newResult) => {
-            log.warn(LOG_AREA, 'rejected server response', {
-                url,
-                body,
-                status: newResult.status,
-                response: newResult.response,
-            });
-
-            throw newResult;
-        });
-    }
-
     return convertedPromise;
 }
 

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -52,16 +52,7 @@ function convertFetchReject(url, body, error) {
  */
 export function convertFetchSuccess(url, body, result) {
     let convertedPromise;
-    if ((result.status < 200 || result.status > 299) && result.status !== 304) {
-        log.error(LOG_AREA, 'rejected server response', {
-            url,
-            body,
-            status: result.status,
-            response: result.response,
-        });
 
-        throw result;
-    }
     const contentType = result.headers.get('content-type');
     if (contentType && contentType.indexOf('application/json') > -1) {
         convertedPromise = result.text()
@@ -136,6 +127,20 @@ export function convertFetchSuccess(url, body, result) {
             };
         });
     }
+
+    if ((result.status < 200 || result.status > 299) && result.status !== 304) {
+        convertedPromise = convertedPromise.then((newResult) => {
+            log.error(LOG_AREA, 'rejected server response', {
+                url,
+                body,
+                status: newResult.status,
+                response: newResult.response,
+            });
+
+            throw newResult;
+        });
+    }
+
     return convertedPromise;
 }
 

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -58,7 +58,7 @@ export function convertFetchResponse(url, body, result, isRejected) {
         log.error(LOG_AREA, 'rejected non-response', {
             url,
             body,
-            result,
+            error: result,  // "error" is processed by the logger in a special way
         });
 
         const networkError = {

--- a/test/unit/openapi/transport/auth-spec.js
+++ b/test/unit/openapi/transport/auth-spec.js
@@ -104,27 +104,105 @@ describe('openapi TransportAuth', () => {
                 });
             });
         });
-        it('fires an event when token refreshing failed', function(done) {
-            const options = { token: 'TOKEN', expiry: relativeDate(60), tokenRefreshUrl: 'http://refresh' };
-            transportAuth = new TransportAuth('localhost/openapi', options);
+        describe('when token refreshing fails', function() {
+            it('fires an event if unauthorized', function(done) {
+                const options = { token: 'TOKEN', expiry: relativeDate(60), tokenRefreshUrl: 'http://refresh' };
+                transportAuth = new TransportAuth('localhost/openapi', options);
 
-            const tokenRefreshFailSpy = jasmine.createSpy('tokenRefreshFail listener');
-            const tokenReceivedSpy = jasmine.createSpy('tokenReceived listener');
-            transportAuth.on(transportAuth.EVENT_TOKEN_REFRESH_FAILED, tokenRefreshFailSpy);
-            transportAuth.on(transportAuth.EVENT_TOKEN_RECEIVED, tokenReceivedSpy);
-            transportAuth.auth.set('TOK2', relativeDate(0));
-            fetch.reject('401', { error: 'not authorised' });
-            tick(function() {
-                transportAuth.off(transportAuth.EVENT_TOKEN_REFRESH_FAILED, tokenRefreshFailSpy);
-                transportAuth.off(transportAuth.EVENT_TOKEN_RECEIVED, tokenReceivedSpy);
-                expect(tokenRefreshFailSpy.calls.count()).toEqual(1);
-
-                transportAuth.auth.set('TOK4', relativeDate(0));
-                fetch.reject('401', { error: 'not authorised' });
+                const tokenRefreshFailSpy = jasmine.createSpy('tokenRefreshFail listener');
+                const tokenReceivedSpy = jasmine.createSpy('tokenReceived listener');
+                transportAuth.on(transportAuth.EVENT_TOKEN_REFRESH_FAILED, tokenRefreshFailSpy);
+                transportAuth.on(transportAuth.EVENT_TOKEN_RECEIVED, tokenReceivedSpy);
+                transportAuth.auth.set('TOK2', relativeDate(0));
+                fetch.reject(401, { error: 'not authorised' });
                 tick(function() {
+                    transportAuth.off(transportAuth.EVENT_TOKEN_REFRESH_FAILED, tokenRefreshFailSpy);
+                    transportAuth.off(transportAuth.EVENT_TOKEN_RECEIVED, tokenReceivedSpy);
                     expect(tokenRefreshFailSpy.calls.count()).toEqual(1);
-                    expect(tokenReceivedSpy.calls.count()).toEqual(0);
-                    done();
+
+                    transportAuth.auth.set('TOK4', relativeDate(0));
+                    fetch.reject(401, { error: 'not authorised' });
+                    tick(function() {
+                        expect(tokenRefreshFailSpy.calls.count()).toEqual(1);
+                        expect(tokenReceivedSpy.calls.count()).toEqual(0);
+                        done();
+                    });
+                });
+            });
+            it('fires an event if forbidden', function(done) {
+                const options = { token: 'TOKEN', expiry: relativeDate(60), tokenRefreshUrl: 'http://refresh' };
+                transportAuth = new TransportAuth('localhost/openapi', options);
+
+                const tokenRefreshFailSpy = jasmine.createSpy('tokenRefreshFail listener');
+                const tokenReceivedSpy = jasmine.createSpy('tokenReceived listener');
+                transportAuth.on(transportAuth.EVENT_TOKEN_REFRESH_FAILED, tokenRefreshFailSpy);
+                transportAuth.on(transportAuth.EVENT_TOKEN_RECEIVED, tokenReceivedSpy);
+                transportAuth.auth.set('TOK2', relativeDate(0));
+                fetch.reject(403, { error: 'forbidden' });
+                tick(function() {
+                    transportAuth.off(transportAuth.EVENT_TOKEN_REFRESH_FAILED, tokenRefreshFailSpy);
+                    transportAuth.off(transportAuth.EVENT_TOKEN_RECEIVED, tokenReceivedSpy);
+                    expect(tokenRefreshFailSpy.calls.count()).toEqual(1);
+
+                    transportAuth.auth.set('TOK4', relativeDate(0));
+                    fetch.reject(403, { error: 'forbidden' });
+                    tick(function() {
+                        expect(tokenRefreshFailSpy.calls.count()).toEqual(1);
+                        expect(tokenReceivedSpy.calls.count()).toEqual(0);
+                        done();
+                    });
+                });
+            });
+            it('fires an event after retrying', function(done) {
+                const options = {
+                    token: 'TOKEN',
+                    expiry: relativeDate(60),
+                    tokenRefreshUrl: 'http://refresh',
+                    maxRetryCount: 1,
+                };
+                transportAuth = new TransportAuth('localhost/openapi', options);
+
+                const tokenRefreshFailSpy = jasmine.createSpy('tokenRefreshFail listener');
+                const tokenReceivedSpy = jasmine.createSpy('tokenReceived listener');
+                transportAuth.on(transportAuth.EVENT_TOKEN_REFRESH_FAILED, tokenRefreshFailSpy);
+                transportAuth.on(transportAuth.EVENT_TOKEN_RECEIVED, tokenReceivedSpy);
+                transportAuth.auth.set('TOK2', relativeDate(0));
+                fetch.reject(new Error('Network error'));
+                tick(function() {
+                    expect(tokenRefreshFailSpy.calls.count()).toEqual(0);
+                    transportAuth.auth.set('TOK4', relativeDate(0));
+                    fetch.reject(new Error('Network error'));
+                    tick(function() {
+                        expect(tokenRefreshFailSpy.calls.count()).toEqual(1);
+                        expect(tokenReceivedSpy.calls.count()).toEqual(0);
+                        done();
+                    });
+                });
+            });
+            it('retries and recovers after a fail', function(done) {
+                const options = {
+                    token: 'TOKEN',
+                    expiry: relativeDate(60),
+                    tokenRefreshUrl: 'http://refresh',
+                    maxRetryCount: 1,
+                };
+                transportAuth = new TransportAuth('localhost/openapi', options);
+
+                const tokenRefreshFailSpy = jasmine.createSpy('tokenRefreshFail listener');
+                const tokenReceivedSpy = jasmine.createSpy('tokenReceived listener');
+                transportAuth.on(transportAuth.EVENT_TOKEN_REFRESH_FAILED, tokenRefreshFailSpy);
+                transportAuth.on(transportAuth.EVENT_TOKEN_RECEIVED, tokenReceivedSpy);
+                transportAuth.auth.set('TOK2', relativeDate(0));
+                fetch.reject(new Error('Network error'));
+                tick(function() {
+                    expect(tokenRefreshFailSpy.calls.count()).toEqual(0);
+                    transportAuth.auth.set('TOK4', relativeDate(0));
+                    fetch.resolve(200, { token: 'TOK5', expiry: 60 });
+                    tick(function() {
+                        expect(tokenRefreshFailSpy.calls.count()).toEqual(0);
+                        expect(tokenReceivedSpy.calls.count()).toEqual(1);
+                        done();
+                    });
                 });
             });
         });

--- a/test/unit/openapi/transport/auth-spec.js
+++ b/test/unit/openapi/transport/auth-spec.js
@@ -114,14 +114,14 @@ describe('openapi TransportAuth', () => {
                 transportAuth.on(transportAuth.EVENT_TOKEN_REFRESH_FAILED, tokenRefreshFailSpy);
                 transportAuth.on(transportAuth.EVENT_TOKEN_RECEIVED, tokenReceivedSpy);
                 transportAuth.auth.set('TOK2', relativeDate(0));
-                fetch.reject(401, { error: 'not authorised' });
+                fetch.resolve(401, { error: 'not authorised' });
                 tick(function() {
                     transportAuth.off(transportAuth.EVENT_TOKEN_REFRESH_FAILED, tokenRefreshFailSpy);
                     transportAuth.off(transportAuth.EVENT_TOKEN_RECEIVED, tokenReceivedSpy);
                     expect(tokenRefreshFailSpy.calls.count()).toEqual(1);
 
                     transportAuth.auth.set('TOK4', relativeDate(0));
-                    fetch.reject(401, { error: 'not authorised' });
+                    fetch.resolve(401, { error: 'not authorised' });
                     tick(function() {
                         expect(tokenRefreshFailSpy.calls.count()).toEqual(1);
                         expect(tokenReceivedSpy.calls.count()).toEqual(0);
@@ -138,14 +138,14 @@ describe('openapi TransportAuth', () => {
                 transportAuth.on(transportAuth.EVENT_TOKEN_REFRESH_FAILED, tokenRefreshFailSpy);
                 transportAuth.on(transportAuth.EVENT_TOKEN_RECEIVED, tokenReceivedSpy);
                 transportAuth.auth.set('TOK2', relativeDate(0));
-                fetch.reject(403, { error: 'forbidden' });
+                fetch.resolve(403, { error: 'forbidden' });
                 tick(function() {
                     transportAuth.off(transportAuth.EVENT_TOKEN_REFRESH_FAILED, tokenRefreshFailSpy);
                     transportAuth.off(transportAuth.EVENT_TOKEN_RECEIVED, tokenReceivedSpy);
                     expect(tokenRefreshFailSpy.calls.count()).toEqual(1);
 
                     transportAuth.auth.set('TOK4', relativeDate(0));
-                    fetch.reject(403, { error: 'forbidden' });
+                    fetch.resolve(403, { error: 'forbidden' });
                     tick(function() {
                         expect(tokenRefreshFailSpy.calls.count()).toEqual(1);
                         expect(tokenReceivedSpy.calls.count()).toEqual(0);

--- a/test/unit/openapi/transport/core-spec.js
+++ b/test/unit/openapi/transport/core-spec.js
@@ -208,7 +208,7 @@ describe('openapi TransportCore', () => {
             transport = new TransportCore('localhost/openapi');
             const getPromise = transport.get('service_group', 'account/info', null);
 
-            fetch.reject(200, { Test: true });
+            fetch.resolve(404, { Test: true });
 
             const getSpy = jasmine.createSpy('getSpy');
             getPromise.catch(getSpy);
@@ -217,7 +217,7 @@ describe('openapi TransportCore', () => {
                 expect(getSpy.calls.count()).toEqual(1);
 
                 const res = getSpy.calls.argsFor(0)[0];
-                expect(res).toEqual(jasmine.objectContaining({ status: 200, response: { Test: true } }));
+                expect(res).toEqual(jasmine.objectContaining({ status: 404, response: { Test: true } }));
                 expect(res.headers.get('content-type')).toEqual('application/json; utf-8');
                 done();
             });

--- a/test/unit/utils/fetch-spec.js
+++ b/test/unit/utils/fetch-spec.js
@@ -1,12 +1,12 @@
-// tests for saxo.utils.fetch.convertFetchResponse
-import { convertFetchResponse } from '../../../src/utils/fetch';
+// tests for saxo.utils.fetch.convertFetchSuccess
+import { convertFetchSuccess } from '../../../src/utils/fetch';
 import { FetchResponse } from '../mocks/fetch';
 
 describe('utils fetch', () => {
     it('images are downloaded as a binary blob', (done) => {
         const contentType = 'image/jpeg';
         const result = new FetchResponse(200, 'this is a binary image', contentType);
-        const promise = convertFetchResponse('url', 'body', result);
+        const promise = convertFetchSuccess('url', 'body', result);
 
         promise.then((response) => {
             expect(response.response).toEqual('this is a binary image');
@@ -22,7 +22,7 @@ describe('utils fetch', () => {
     it('json is downloaded and converted to an object', (done) => {
         const contentType = 'application/json';
         const result = new FetchResponse(200, '{"test":1}', contentType);
-        const promise = convertFetchResponse('url', 'body', result);
+        const promise = convertFetchSuccess('url', 'body', result);
 
         promise.then((response) => {
             expect(response.response).toEqual({ test: 1 });
@@ -38,7 +38,7 @@ describe('utils fetch', () => {
     it('xslx is downloaded as a binary blob', (done) => {
         const contentType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
         const result = new FetchResponse(200, 'this is a binary string', contentType);
-        const promise = convertFetchResponse('url', 'body', result);
+        const promise = convertFetchSuccess('url', 'body', result);
 
         promise.then((response) => {
             expect(response.response).toEqual('this is a binary string');
@@ -54,7 +54,7 @@ describe('utils fetch', () => {
     it('unknown file types are downloaded as text', (done) => {
         const contentType = 'unknown/file';
         const result = new FetchResponse(200, 'this is a string', contentType);
-        const promise = convertFetchResponse('url', 'body', result);
+        const promise = convertFetchSuccess('url', 'body', result);
 
         promise.then((response) => {
             expect(response.response).toEqual('this is a string');
@@ -65,11 +65,5 @@ describe('utils fetch', () => {
         });
 
         Promise.resolve(promise);
-    });
-
-    it('empty responses throw an error', () => {
-        expect(() => {
-            convertFetchResponse('url', 'body', null);
-        }).toThrow();
     });
 });


### PR DESCRIPTION
 - Retry oAuth token refresh before triggering fail event. This should only happen if the error is caused by a network failure, and not if the response code is 401 or 403.

 - Better logging when a fetch calls results in an error 