### PR TITLE
Fallback support for protobuf requests.

### DIFF
--- a/src/openapi/streaming/subscription.js
+++ b/src/openapi/streaming/subscription.js
@@ -314,9 +314,10 @@ function onSubscribeError(referenceId, response) {
 
     const errorCode = response && response.response ? response.response.ErrorCode : null;
 
-    if (errorCode === ERROR_UNSUPPORTED_FORMAT && this.subscriptionData.Format === FORMAT_PROTOBUF) {
+    if (errorCode === ERROR_UNSUPPORTED_FORMAT && this.subscriptionData && this.subscriptionData.Format === FORMAT_PROTOBUF) {
         // Fallback to JSON format if specific endpoint doesn't support PROTOBUF format.
         this.subscriptionData.Format = FORMAT_JSON;
+        this.serializer = SerializerFacade.getSerializer(FORMAT_JSON, this.serviceGroup, this.url);
 
         tryPerformAction.call(this, ACTION_SUBSCRIBE);
         return;

--- a/test/unit/openapi/streaming/subscription-spec.js
+++ b/test/unit/openapi/streaming/subscription-spec.js
@@ -159,23 +159,7 @@ describe('openapi StreamingSubscription', () => {
                 expect(subscription.subscriptionData, 'application/json');
 
                 expect(transport.post.calls.count()).toEqual(1);
-
-                const expectedArgs = [
-                    'serviceGroup',
-                    'test/resource',
-                    null,
-                    {
-                        body: {
-                            Format: 'application/json',
-                            RefreshRate: 1000,
-                            ContextId: '123',
-                            ReferenceId: '2',
-                            KnownSchemas: undefined,
-                        },
-                    },
-                ];
-
-                expect(transport.post.calls.argsFor(0)).toEqual(expectedArgs);
+                expect(transport.post.calls.argsFor(0)[3].body.Format, 'application/json');
 
                 done();
             });


### PR DESCRIPTION
### Problem

Some openapi endpoints don't support protobuf (at this point only one).

### Solution

If protobuf is not supported by specific endpoint, try to subscribe using default json format.
Do it only once per subscription instance.