### PR TITLE
Add authorization error (401) limits to block infinite loop of auth token requests

### DIFF
--- a/src/openapi/transport/auth.js
+++ b/src/openapi/transport/auth.js
@@ -22,8 +22,10 @@ const DEFAULT_TOKEN_REFRESH_CREDDENTIALS = 'include';
 
 // Max request limits are used to block infinite loop of authorization requests after transport 401 errors, which my happen if given
 // endpoint for whatever reasons constantly returns 401 error status (despite correct fresh authorization token refresh).
-const DEFAULT_MAX_AUTH_ERRORS = 10;
-const DEFAULT_AUTH_ERRORS_CLEANUP_DEBOUNCE = 1000;
+const DEFAULT_MAX_AUTH_ERRORS = 3;
+
+// Debounce time in milliseconds.
+const DEFAULT_AUTH_ERRORS_CLEANUP_DEBOUNCE = 5000; // ms
 
 const TOKEN_BEARER = 'Bearer ';
 
@@ -168,7 +170,7 @@ function onTransportError(oldTokenExpiry, result) {
         const shouldRequest = (isCurrentTokenInvalid || isCurrentTokenExpired) && !isFetching;
         const urlErrorCount = this.getUrlErrorCount(result.url);
 
-        if (urlErrorCount > this.maxAuthErrors) {
+        if (urlErrorCount >= this.maxAuthErrors) {
             // Blocking infinite loop of authorization re-requests which might be caused by invalid
             // behaviour of given endpoint which constantly returns 401 error.
             log.error(LOG_AREA, 'Too many authorization errors occurred withing specified timeframe for specific endpoint.');
@@ -243,7 +245,7 @@ function onTransportError(oldTokenExpiry, result) {
  * @param {number} [options.maxRetryCount] - The maximum number of times to retry the auth url
  * @param {number} [options.maxAuthErrors] - The maximum number of authorization errors that
  *          can occur for specific endpoint within specific timeframe.
- * @param {number} [options.authErrorsCleanupDebounce] - The debounce timeout used for clearing of authorization errors count.
+ * @param {number} [options.authErrorsCleanupDebounce] - The debounce timeout (in ms) used for clearing of authorization errors count.
  */
 function TransportAuth(baseUrl, options) {
 

--- a/src/openapi/transport/auth.js
+++ b/src/openapi/transport/auth.js
@@ -20,6 +20,11 @@ const DEFAULT_TOKEN_REFRESH_PROPERTY_NAME_EXPIRES = 'expiry';
 const DEFAULT_TOKEN_REFRESH_MARGIN_MS = 0;
 const DEFAULT_TOKEN_REFRESH_CREDDENTIALS = 'include';
 
+// Max request limits are used to block infinite loop of authorization requests after transport 401 errors, which my happen if given
+// endpoint for whatever reasons constantly returns 401 error status (despite correct fresh authorization token refresh).
+const DEFAULT_MAX_AUTH_ERRORS = 10;
+const DEFAULT_AUTH_ERRORS_CLEANUP_DEBOUNCE = 1000;
+
 const TOKEN_BEARER = 'Bearer ';
 
 const STATE_WAITING = 0x1;
@@ -144,6 +149,11 @@ function makeTransportMethod(method) {
     };
 }
 
+function onErrorCleanupTimeout() {
+    this.authorizationErrorCount = {};
+    this.errorCleanupTimoutId = null;
+}
+
 function onTransportError(oldTokenExpiry, result) {
     if (result && result.status === 401) {
         const currentAuthExpiry = this.auth.getExpiry();
@@ -155,6 +165,15 @@ function onTransportError(oldTokenExpiry, result) {
         const isCurrentTokenExpired = currentAuthExpiry < now;
         // if we are not in an ok waiting state
         const isFetching = !(this.state & STATE_WAITING && this.retries === 0);
+        const shouldRequest = (isCurrentTokenInvalid || isCurrentTokenExpired) && !isFetching;
+        const urlErrorCount = this.getUrlErrorCount(result.url);
+
+        if (urlErrorCount > this.maxAuthErrors) {
+            // Blocking infinite loop of authorization re-requests which might be caused by invalid
+            // behaviour of given endpoint which constantly returns 401 error.
+            log.error(LOG_AREA, 'Too many authorization errors occurred withing specified timeframe for specific endpoint.');
+            return;
+        }
 
         if (isCurrentTokenInvalid) {
             if (isFetching) {
@@ -184,7 +203,9 @@ function onTransportError(oldTokenExpiry, result) {
             });
         }
 
-        if ((isCurrentTokenInvalid || isCurrentTokenExpired) && !isFetching) {
+        if (shouldRequest) {
+            this.incrementErrorCounter(result.url);
+            this.debounceErrorCounterCleanup();
             this.refreshOpenApiToken();
         }
     }
@@ -220,6 +241,9 @@ function onTransportError(oldTokenExpiry, result) {
  * @param {string|number} [options.expiry] - The expiry of that token, assumed to be absolute.
  * @param {number} [options.retryDelayMs] - The delay before retrying auth
  * @param {number} [options.maxRetryCount] - The maximum number of times to retry the auth url
+ * @param {number} [options.maxAuthErrors] - The maximum number of authorization errors that
+ *          can occur for specific endpoint within specific timeframe.
+ * @param {number} [options.authErrorsCleanupDebounce] - The debounce timeout used for clearing of authorization errors count.
  */
 function TransportAuth(baseUrl, options) {
 
@@ -234,10 +258,15 @@ function TransportAuth(baseUrl, options) {
     this.tokenRefreshMarginMs = options && options.tokenRefreshMarginMs || DEFAULT_TOKEN_REFRESH_MARGIN_MS;
     this.retryDelayMs = options && options.retryDelayMs || DEFAULT_RETRY_DELAY_MS;
     this.maxRetryCount = options && options.maxRetryCount || DEFAULT_MAX_RETRY_COUNT;
+    this.maxAuthErrors = options && options.maxAuthErrors || DEFAULT_MAX_AUTH_ERRORS;
+    this.authErrorsCleanupDebounce = options && options.authErrorsCleanupDebounce || DEFAULT_AUTH_ERRORS_CLEANUP_DEBOUNCE;
 
     this.transport = new TransportCore(baseUrl, options);
     this.state = STATE_WAITING;
     this.retries = 0;
+
+    // Map of authorization error counts per endpoint/url.
+    this.authorizationErrorCount = {};
 
     const token = options && options.token || null;
     let expiry = options && options.expiry || 0;
@@ -341,9 +370,49 @@ TransportAuth.prototype.refreshOpenApiToken = function() {
 };
 
 /**
+ * Run debounced cleanup of error counter map
+ */
+TransportAuth.prototype.debounceErrorCounterCleanup = function() {
+    if (this.errorCleanupTimoutId) {
+        clearTimeout(this.errorCleanupTimoutId);
+    }
+
+    this.errorCleanupTimoutId = setTimeout(onErrorCleanupTimeout.bind(this), this.authErrorsCleanupDebounce);
+};
+
+/**
+ * Increment error counter for specific url/endpoint.
+ * @param {string} url - The url/endpoint for which error count is incremented.
+ */
+TransportAuth.prototype.incrementErrorCounter = function(url) {
+    if (this.authorizationErrorCount.hasOwnProperty(url)) {
+        this.authorizationErrorCount[url] = this.authorizationErrorCount[url] + 1;
+    } else {
+        this.authorizationErrorCount[url] = 1;
+    }
+};
+
+/**
+ * Get error count for specific url/endpoint
+ * @param {string} url - The url/endpoint for which error count is returned.
+ * @returns {number} The number of errors
+ */
+TransportAuth.prototype.getUrlErrorCount = function(url) {
+    if (this.authorizationErrorCount.hasOwnProperty(url)) {
+        return this.authorizationErrorCount[url];
+    }
+
+    return 0;
+};
+
+/**
  * Stops the transport from refreshing the token.
  */
 TransportAuth.prototype.dispose = function() {
+    clearTimeout(this.errorCleanupTimoutId);
+    this.errorCleanupTimoutId = null;
+    this.authorizationErrorCount = {};
+
     if (this.tokenRefreshTimer) {
         clearTimeout(this.tokenRefreshTimer);
     }

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -16,6 +16,40 @@ function tick(func) {
     realSetTimeout(func, 1); // for when running in a modern browser (that doesn't fallback to nextTick=setTimeout)
 }
 
+/**
+ * Recurrent loop which asynchronously one after another, invokes list of methods wrapped with tick.
+ * @param {function} cursor - The function which will be invoked inside tick wrapper.
+ * @param {array} list - The array of methods to be invoked asynchronously through tick wrapper one after another.
+ */
+function tickRecurrentLoop(cursor, list) {
+    if (!cursor) {
+        return;
+    }
+
+    tick(() => {
+        cursor();
+        tickRecurrentLoop(list.shift(), list);
+    });
+}
+
+/**
+ * Invoke list of methods as async ticks (one after another).
+ * Useful alternative to nested callback hell.
+ * @param {array} list - The array of actions which will be invoked as a ticks, one after another (async).
+ * @param {boolean} startImmediately - The flag which causes first method to be invoked without tick wrapper.
+ */
+function tickArray(list, startImmediately = false) {
+    if (!list || list.length === 0) {
+        return;
+    }
+
+    if (startImmediately) {
+        list.shift()();
+    }
+
+    tickRecurrentLoop(list.shift(), list);
+}
+
 // eslint-disable-next-line no-eval
 const global = (0, eval)('this');
 
@@ -35,4 +69,12 @@ function uninstallClock() {
     jasmine.clock().uninstall();
 }
 
-export { tick, global, multiline, installClock, uninstallClock, mockDate };
+export {
+    tick,
+    tickArray,
+    global,
+    multiline,
+    installClock,
+    uninstallClock,
+    mockDate,
+};


### PR DESCRIPTION
Fix introduces guard for maximum authorization fails that can happen within defined period of time (with debounce).

So for example if specific authorization endpoint fails 3 times, where each fail was within 5s timeframe, we block further error handling for this endpoint, until more then 5s passes.
This blocks further loop of endpoint errors and oauth re-requests.

Generally, scenario being fixed here is edge case end should never happen by design. However we had cases where openapi errors caused specific endpoint to always return 401 when requested.
By desing, on our side, if authorization error is returned for specific endpoint (which my happen by design), we request fresh authorization token. However, if endpoint is broken, and returns 401 for valid, fresh authorization tokens, we were re-requesting tokesn forever. And this change guards against infinite requests.