### PR TITLE
feat: add Request ID from OpenAPI to error logging

### DIFF
--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -137,7 +137,7 @@ export function convertFetchSuccess(url, body, timerId, result) {
             const correlation = result.headers.get('x-correlation') || '';
             
             // Form of correlation header is: {sessionId}#{AppId}#{requestId}#{serverDigits}
-            const [,,requestId] = correlation.split('#'); 
+            const requestId = correlation.split('#')[2]; 
 
             log.error(LOG_AREA, 'rejected server response', {
                 url,

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -135,9 +135,9 @@ export function convertFetchSuccess(url, body, timerId, result) {
     if ((result.status < 200 || result.status > 299) && result.status !== 304) {
         convertedPromise = convertedPromise.then((newResult) => {
             const correlation = result.headers.get('x-correlation') || '';
-            
+
             // Form of correlation header is: {sessionId}#{AppId}#{requestId}#{serverDigits}
-            const requestId = correlation.split('#')[2]; 
+            const requestId = correlation.split('#')[2];
 
             log.error(LOG_AREA, 'rejected server response', {
                 url,

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -144,7 +144,7 @@ export function convertFetchSuccess(url, body, timerId, result) {
                 body,
                 status: newResult.status,
                 response: newResult.response,
-                requestId: requestId === '' ? null : requestId,
+                requestId: requestId || null,
             });
 
             throw newResult;

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -134,13 +134,17 @@ export function convertFetchSuccess(url, body, timerId, result) {
 
     if ((result.status < 200 || result.status > 299) && result.status !== 304) {
         convertedPromise = convertedPromise.then((newResult) => {
-            const requestId = parseInt(result.headers.get('x-request-id'), 10);
+            const correlation = result.headers.get('x-correlation') || '';
+            
+            // Form of correlation header is: {sessionId}#{AppId}#{requestId}#{serverDigits}
+            const [,,requestId] = correlation.split('#'); 
+
             log.error(LOG_AREA, 'rejected server response', {
                 url,
                 body,
                 status: newResult.status,
                 response: newResult.response,
-                requestId: isNaN(requestId) ? null : requestId,
+                requestId: requestId === '' ? null : requestId,
             });
 
             throw newResult;

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -134,11 +134,13 @@ export function convertFetchSuccess(url, body, timerId, result) {
 
     if ((result.status < 200 || result.status > 299) && result.status !== 304) {
         convertedPromise = convertedPromise.then((newResult) => {
+            const requestId = parseInt(result.headers.get('x-request-id'), 10);
             log.error(LOG_AREA, 'rejected server response', {
                 url,
                 body,
                 status: newResult.status,
                 response: newResult.response,
+                requestId: isNaN(requestId) ? null : requestId,
             });
 
             throw newResult;


### PR DESCRIPTION
Adds request ID passed from OpenAPI to the error logging.

Note: The header name might change after discussion with the OpenAPI teams.

Internal PR #: 30747