### PR TITLE
Default body to empty object for PATCH requests without body.

### DIFF
--- a/src/openapi/transport/auth.spec.js
+++ b/src/openapi/transport/auth.spec.js
@@ -500,7 +500,16 @@ describe('openapi TransportAuth', () => {
             expect(fetch.mock.calls[0]).toEqual([expect.anything(), expect.objectContaining({ headers: { Authorization: 'Bearer TOKEN', 'X-Request-Id': expect.any(Number) } })]);
             expect(fetch.mock.calls[1]).toEqual([expect.anything(), expect.objectContaining({ headers: { Authorization: 'Bearer TOKEN', 'X-Request-Id': expect.any(Number) } })]);
             expect(fetch.mock.calls[2]).toEqual([expect.anything(), expect.objectContaining({ headers: { Authorization: 'Bearer TOKEN', 'X-Request-Id': expect.any(Number) } })]);
-            expect(fetch.mock.calls[3]).toEqual([expect.anything(), expect.objectContaining({ headers: { Authorization: 'Bearer TOKEN', 'X-Request-Id': expect.any(Number) } })]);
+            expect(fetch.mock.calls[3]).toEqual([
+                expect.anything(),
+                expect.objectContaining({
+                    headers: {
+                        Authorization: 'Bearer TOKEN',
+                        'X-Request-Id': expect.any(Number),
+                        'Content-Type': expect.any(String),
+                    },
+                }),
+            ]);
             expect(fetch.mock.calls[4]).toEqual([expect.anything(), expect.objectContaining({ headers: { Authorization: 'Bearer TOKEN', 'X-Request-Id': expect.any(Number) } })]);
         });
 

--- a/src/openapi/transport/core.spec.js
+++ b/src/openapi/transport/core.spec.js
@@ -461,8 +461,34 @@ describe('openapi TransportCore', () => {
                 .toEqual([expect.anything(),
                     expect.objectContaining({
                         method: 'POST',
+                        body: '{}',
                         headers: {
+                            'Content-Type': 'application/json; charset=UTF-8',
                             'X-HTTP-Method-Override': 'PATCH',
+                            'X-Request-Id': expect.any(Number),
+                        } })]);
+            fetch.mockClear();
+        });
+    });
+
+    describe('PATCH body defaulting', () => {
+
+        beforeEach(() => {
+            transport = new TransportCore('localhost/openapi');
+        });
+
+        afterEach(() => transport.dispose());
+
+        it('works', () => {
+            transport.patch('service_group', 'url', null, { body: { exampleField: 'test' } });
+            expect(fetch.mock.calls.length).toEqual(1);
+            expect(fetch.mock.calls[0])
+                .toEqual([expect.anything(),
+                    expect.objectContaining({
+                        method: 'PATCH',
+                        body: '{"exampleField":"test"}',
+                        headers: {
+                            'Content-Type': 'application/json; charset=UTF-8',
                             'X-Request-Id': expect.any(Number),
                         } })]);
             fetch.mockClear();

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -149,14 +149,14 @@ export function convertFetchSuccess(url, body, timerId, result) {
 }
 
 function getBody(method, options) {
-    if (!options) {
-        return null;
-    }
-
     // If PATCH without body occurs, create empty payload.
     // Reason: Some proxies and default configs for CDNs like Akamai have issues with accepting PATCH with content-length: 0.
-    if (method === 'PATCH' && !options.body && !options.useXHttpMethodOverride) {
+    if (method === 'PATCH' && (!options || !options.body)) {
         return {};
+    }
+
+    if (!options) {
+        return null;
     }
 
     return options.body;

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -148,6 +148,20 @@ export function convertFetchSuccess(url, body, timerId, result) {
     return convertedPromise;
 }
 
+function getBody(method, options) {
+    if (!options) {
+        return null;
+    }
+
+    // If PATCH without body occurs, create empty payload.
+    // Reason: Some proxies and default configs for CDNs like Akamai have issues with accepting PATCH with content-length: 0.
+    if (method === 'PATCH' && !options.body && !options.useXHttpMethodOverride) {
+        return {};
+    }
+
+    return options.body;
+}
+
 // -- Exported methods section --
 
 /**
@@ -176,8 +190,7 @@ export function convertFetchSuccess(url, body, timerId, result) {
  * @return {Promise<{ status: number, response: Object|String, headers: Object },{ status: number, response: Object|String, headers: Object }|Error>}
  */
 function localFetch(method, url, options) {
-
-    let body = options && options.body;
+    let body = getBody(method, options);
     const headers = (options && options.headers) || {};
     const cache = options && options.cache;
     let credentials = options && options.credentials;


### PR DESCRIPTION
Change: Default body to empty object for PATCH requests without body

Reason: Some proxies and default configs for CDNs like Akamai have issues with accepting PATCH with content-length: 0.