### PR TITLE
Bug protobuf fallback logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "4.5.4-protobuf-retry",
+  "version": "4.5.4",
   "engines": {
     "node": ">=4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "4.5.2",
+  "version": "4.5.2-protobuf-retry",
   "engines": {
     "node": ">=4"
   },

--- a/src/openapi/streaming/subscription.js
+++ b/src/openapi/streaming/subscription.js
@@ -305,13 +305,6 @@ function onSubscribeError(referenceId, response) {
         subscriptionData: this.subscriptionData,
     });
 
-    // if we are unsubscribed, do not fire the error handler
-    if (this.queue.peekAction() !== ACTION_UNSUBSCRIBE) {
-        if (this.onError) {
-            this.onError(response);
-        }
-    }
-
     const errorCode = response && response.response ? response.response.ErrorCode : null;
 
     if (errorCode === ERROR_UNSUPPORTED_FORMAT && this.subscriptionData && this.subscriptionData.Format === FORMAT_PROTOBUF) {
@@ -321,6 +314,13 @@ function onSubscribeError(referenceId, response) {
 
         tryPerformAction.call(this, ACTION_SUBSCRIBE);
         return;
+    }
+
+    // if we are unsubscribed, do not fire the error handler
+    if (this.queue.peekAction() !== ACTION_UNSUBSCRIBE) {
+        if (this.onError) {
+            this.onError(response);
+        }
     }
 
     onReadyToPerformNextAction.call(this);

--- a/src/openapi/streaming/subscription.spec.js
+++ b/src/openapi/streaming/subscription.spec.js
@@ -154,6 +154,7 @@ describe('openapi StreamingSubscription', () => {
             transport.post.mockClear();
 
             setTimeout(() => {
+                expect(errorSpy.mock.calls.length).toEqual(0);
                 expect(subscription.subscriptionData.Format).toEqual('application/json');
 
                 expect(transport.post.mock.calls.length).toEqual(1);

--- a/src/openapi/streaming/subscription.spec.js
+++ b/src/openapi/streaming/subscription.spec.js
@@ -154,8 +154,6 @@ describe('openapi StreamingSubscription', () => {
             transport.post.mockClear();
 
             setTimeout(() => {
-                expect(errorSpy.mock.calls.length).toEqual(1);
-                expect(errorSpy.mock.calls[0]).toEqual([{ status: '404', response: { ErrorCode: 'UnsupportedSubscriptionFormat' } }]);
                 expect(subscription.subscriptionData.Format).toEqual('application/json');
 
                 expect(transport.post.mock.calls.length).toEqual(1);


### PR DESCRIPTION
Fix for protobuf logic.

## Problem
Currently when endpoint doesn't support protobuf, endpoint returns an error and openapi-clientlib fallbacks to json subscription.
However in addition to a subscribe, we also send an error message which in our GO sagas drops/locks subscription from further passing updates.

## Solution
To be backward compatible, I've dropped invoking error callbacks when endpoint fails due to protobuf format being unsupported.
This ensure that userspace can keep current error handling logic with duplicated code need for handling protobuf errors.
So in short. Due to error being inreversible/fatal one, we only now send it whenever subscription fails without fallback. However in fallback scenarios fatal error isn't sent.

## Alternative options

If we decide to keep error being invoked, we should then drop re-connect logic as well and require it to be implemented on user space side.