### PR TITLE
avoid mutating header options

### DIFF
--- a/src/openapi/streaming/subscription.js
+++ b/src/openapi/streaming/subscription.js
@@ -73,7 +73,11 @@ function subscribe() {
         ReferenceId: referenceId,
         KnownSchemas: this.parser.getSchemaNames(),
     });
-    const options = { body: data, headers: extend({}, this.headers) };
+    const options = { body: data };
+
+    if (this.headers) {
+        options.headers = extend({}, this.headers);
+    }
 
     normalizeSubscribeData(data);
 
@@ -449,7 +453,7 @@ function Subscription(streamingContextId, transport, serviceGroup, url, subscrip
     this.onUpdate = options.onUpdate;
     this.onError = options.onError;
     this.onQueueEmpty = options.onQueueEmpty;
-    this.headers = options.headers;
+    this.headers = options.headers && extend({}, options.headers);
 
     if (!this.subscriptionData.RefreshRate) {
         this.subscriptionData.RefreshRate = DEFAULT_REFRESH_RATE_MS;

--- a/src/openapi/streaming/subscription.js
+++ b/src/openapi/streaming/subscription.js
@@ -73,7 +73,7 @@ function subscribe() {
         ReferenceId: referenceId,
         KnownSchemas: this.parser.getSchemaNames(),
     });
-    const options = { body: data, headers: Object.assign({}, this.headers) };
+    const options = { body: data, headers: extend({}, this.headers) };
 
     normalizeSubscribeData(data);
 

--- a/src/openapi/streaming/subscription.js
+++ b/src/openapi/streaming/subscription.js
@@ -73,19 +73,14 @@ function subscribe() {
         ReferenceId: referenceId,
         KnownSchemas: this.parser.getSchemaNames(),
     });
+    const options = { body: data, headers: Object.assign({}, this.headers) };
 
     normalizeSubscribeData(data);
-
-    const args = { body: data };
-
-    if (this.headers) {
-        args.headers = this.headers;
-    }
 
     log.debug(LOG_AREA, 'starting..', { serviceGroup: this.serviceGroup, url: subscribeUrl });
     setState.call(this, this.STATE_SUBSCRIBE_REQUESTED);
 
-    this.transport.post(this.serviceGroup, subscribeUrl, null, args)
+    this.transport.post(this.serviceGroup, subscribeUrl, null, options)
         .then(onSubscribeSuccess.bind(this, referenceId))
         .catch(onSubscribeError.bind(this, referenceId));
 }


### PR DESCRIPTION
Some transports may append to the headers object. This can cause trouble since it will mutate the passed `options.headers` object.
This change creates a new `headers` object before passing it on, avoiding potential for mutation.
