### PR TITLE
Adding support for 'application/octet-stream' content type

### DIFF
--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -12,6 +12,7 @@ const LOG_AREA = 'Fetch';
 // list of content-types that will be treated as binary blobs
 const binaryContentTypes = {
     'application/pdf': true,
+    'application/octet-stream': true,
     'application/vnd.ms-excel': true,
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': true,
 };

--- a/src/utils/fetch.spec.js
+++ b/src/utils/fetch.spec.js
@@ -19,6 +19,22 @@ describe('utils fetch', () => {
         Promise.resolve(promise);
     });
 
+    it('octet-stream are downloaded as a binary blob', (done) => {
+        const contentType = 'application/octet-stream';
+        const result = new FetchResponse(200, 'this is generic binary data', contentType);
+        const promise = convertFetchSuccess('url', 'body', 0, result);
+
+        promise.then((response) => {
+            expect(response.response).toEqual('this is generic binary data');
+            expect(response.status).toEqual(200);
+            expect(response.headers.get('content-type')).toEqual(contentType);
+            expect(response.responseType).toEqual('blob');
+            done();
+        });
+
+        Promise.resolve(promise);
+    });
+
     it('json is downloaded and converted to an object', (done) => {
         const contentType = 'application/json';
         const result = new FetchResponse(200, '{"test":1}', contentType);


### PR DESCRIPTION
Since the recommended action for an implementation that receives an "application/octet-stream" entity is to simply offer to put the data in a file,

Adding support for `application/octet-stream` in binaryContentTypes list for data to be treated as binary blobs.