### PR TITLE
Add more details to selected sub reset error logs

### DIFF
--- a/src/openapi/streaming/subscription.js
+++ b/src/openapi/streaming/subscription.js
@@ -349,7 +349,11 @@ function onUnsubscribeSuccess(referenceId, response) {
  */
 function onUnsubscribeError(referenceId, response) {
     if (referenceId !== this.referenceId) {
-        log.error(LOG_AREA, 'Received an error response for unsubscribing a subscription that has afterwards been reset - ignoring');
+        log.error(
+            LOG_AREA,
+            'Received an error response for unsubscribing a subscription that has afterwards been reset - ignoring',
+            { response, url: this.url, newReferenceId: referenceId, oldReferenceId: this.referenceId }
+        );
         return;
     }
 
@@ -379,7 +383,11 @@ function onModifyPatchSuccess(referenceId, response) {
  */
 function onModifyPatchError(referenceId, response) {
     if (referenceId !== this.referenceId) {
-        log.error(LOG_AREA, 'Received an error response for modify patch a subscription that has afterwards been reset - ignoring');
+        log.error(
+            LOG_AREA,
+            'Received an error response for modify patch a subscription that has afterwards been reset - ignoring',
+            { response, url: this.url, newReferenceId: referenceId, oldReferenceId: this.referenceId }
+        );
         return;
     }
 


### PR DESCRIPTION
Add more details for error logs related to subscription reset and subscription errors.
This will make it easier to investigate live occurrences for this errors.