### PR TITLE
Add delay levels for streaming total reconnects.

### DIFF
--- a/src/openapi/streaming/streaming.js
+++ b/src/openapi/streaming/streaming.js
@@ -91,7 +91,7 @@ function setNewContextId() {
  * @param defaultDelay {number} - The default delay.
  * @returns {number} Matching delay to retry index/try/count.
  */
-function findRetryDelay(retryLevels, retryIndex, defaultDelay) {
+export function findRetryDelay(retryLevels, retryIndex, defaultDelay) {
     let lastFoundDelay = defaultDelay;
 
     for (let i = 0; i < retryLevels.length; i++) {
@@ -152,7 +152,6 @@ function onConnectionStateChanged(nextState) {
             break;
 
         case this.CONNECTION_STATE_RECONNECTING:
-            this.retryCount = 0;
             updateConnectionQuery.call(this);
 
             this.orphanFinder.stop();

--- a/src/openapi/streaming/streaming.spec.js
+++ b/src/openapi/streaming/streaming.spec.js
@@ -389,11 +389,11 @@ describe('openapi Streaming', () => {
             const connectRetryDelay = 9000;
 
             givenStreaming({ connectRetryDelayLevels: mockRetryLevels, connectRetryDelay });
-            stateChangedCallback({ newState: 0 /* connecting */});
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 0 /* connecting */ });
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             // First disconnect
-            stateChangedCallback({ newState: 4 /* disconnected */});
+            stateChangedCallback({ newState: 4 /* disconnected */ });
 
             expect(subscription.streamingContextId).toEqual('0000000000');
             expect(subscription.streamingContextId).toEqual(streaming.contextId);
@@ -401,8 +401,8 @@ describe('openapi Streaming', () => {
             tick(9000);
 
             expect(mockConnection.start.mock.calls.length).toEqual(2);
-            stateChangedCallback({ newState: 0 /* connecting */});
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 0 /* connecting */ });
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             expect(subscription.streamingContextId).toEqual('0000900000');
             expect(subscription.streamingContextId).toEqual(streaming.contextId);
@@ -413,11 +413,11 @@ describe('openapi Streaming', () => {
             const connectRetryDelay = 7500;
 
             givenStreaming({ connectRetryDelayLevels: mockRetryLevels, connectRetryDelay });
-            stateChangedCallback({ newState: 0 /* connecting */});
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 0 /* connecting */ });
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             // First disconnect
-            stateChangedCallback({ newState: 4 /* disconnected */});
+            stateChangedCallback({ newState: 4 /* disconnected */ });
 
             expect(subscription.streamingContextId).toEqual('0000000000');
             expect(subscription.streamingContextId).toEqual(streaming.contextId);
@@ -425,8 +425,8 @@ describe('openapi Streaming', () => {
             tick(7500);
 
             expect(mockConnection.start.mock.calls.length).toEqual(2);
-            stateChangedCallback({ newState: 0 /* connecting */});
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 0 /* connecting */ });
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             expect(subscription.streamingContextId).toEqual('0000750000');
             expect(subscription.streamingContextId).toEqual(streaming.contextId);
@@ -440,11 +440,11 @@ describe('openapi Streaming', () => {
             ];
 
             givenStreaming({ connectRetryDelayLevels: mockRetryLevels });
-            stateChangedCallback({ newState: 0 /* connecting */});
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 0 /* connecting */ });
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             // First disconnect
-            stateChangedCallback({ newState: 4 /* disconnected */});
+            stateChangedCallback({ newState: 4 /* disconnected */ });
 
             expect(subscription.streamingContextId).toEqual('0000000000');
             expect(subscription.streamingContextId).toEqual(streaming.contextId);
@@ -452,47 +452,47 @@ describe('openapi Streaming', () => {
             tick(2500);
 
             expect(mockConnection.start.mock.calls.length).toEqual(2);
-            stateChangedCallback({ newState: 0 /* connecting */});
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 0 /* connecting */ });
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             expect(subscription.streamingContextId).toEqual('0000250000');
             expect(subscription.streamingContextId).toEqual(streaming.contextId);
 
             // Second disconnect
 
-            stateChangedCallback({ newState: 4 /* disconnected */});
+            stateChangedCallback({ newState: 4 /* disconnected */ });
 
             tick(5000);
 
             expect(mockConnection.start.mock.calls.length).toEqual(3);
-            stateChangedCallback({ newState: 0 /* connecting */});
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 0 /* connecting */ });
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             expect(subscription.streamingContextId).toEqual('0000750000');
             expect(subscription.streamingContextId).toEqual(streaming.contextId);
 
             // Third disconnect
 
-            stateChangedCallback({ newState: 4 /* disconnected */});
+            stateChangedCallback({ newState: 4 /* disconnected */ });
 
             tick(7000);
 
             expect(mockConnection.start.mock.calls.length).toEqual(4);
-            stateChangedCallback({ newState: 0 /* connecting */});
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 0 /* connecting */ });
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             expect(subscription.streamingContextId).toEqual('0001450000');
             expect(subscription.streamingContextId).toEqual(streaming.contextId);
 
             // Forth disconnect
 
-            stateChangedCallback({ newState: 4 /* disconnected */});
+            stateChangedCallback({ newState: 4 /* disconnected */ });
 
             tick(7000);
 
             expect(mockConnection.start.mock.calls.length).toEqual(5);
-            stateChangedCallback({ newState: 0 /* connecting */});
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 0 /* connecting */ });
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             expect(subscription.streamingContextId).toEqual('0002150000');
             expect(subscription.streamingContextId).toEqual(streaming.contextId);
@@ -582,7 +582,7 @@ describe('openapi Streaming', () => {
         let subscription;
         beforeEach(() => {
             streaming = new Streaming(transport, 'testUrl', authProvider);
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 1 /* connected */ });
             subscription = mockSubscription();
             subscription.referenceId = 'MySpy';
             streaming.subscriptions.push(subscription);
@@ -629,7 +629,7 @@ describe('openapi Streaming', () => {
     describe('dispose', () => {
         it('unsubscribes everything', () => {
             const streaming = new Streaming(transport, 'testUrl', authProvider);
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             const subscription = mockSubscription();
             subscription.referenceId = 'MySpy';
@@ -649,7 +649,7 @@ describe('openapi Streaming', () => {
             expect(transport.delete.mock.calls[0][2]).toEqual({ contextId: '0000000000' });
             expect(streaming.orphanFinder.stop.mock.calls.length).toEqual(1);
 
-            stateChangedCallback({ newState: 4 /* disconnected */});
+            stateChangedCallback({ newState: 4 /* disconnected */ });
 
             tick(10000);
             expect(mockConnection.start.mock.calls.length).toEqual(0);
@@ -657,7 +657,7 @@ describe('openapi Streaming', () => {
 
         it('disposes an individual subscription', () => {
             const streaming = new Streaming(transport, 'testUrl', authProvider);
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             const subscription = mockSubscription();
             subscription.referenceId = 'MySpy';
@@ -692,7 +692,7 @@ describe('openapi Streaming', () => {
 
         it('when a subscription is orphaned, the subscription is reset', () => {
             const streaming = new Streaming(transport, 'testUrl', authProvider);
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             const subscription = mockSubscription();
             subscription.referenceId = 'MySpy';
@@ -706,7 +706,7 @@ describe('openapi Streaming', () => {
 
         it('passes on subscribe calls', () => {
             const streaming = new Streaming(transport, 'testUrl', authProvider);
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             const subscription = mockSubscription();
             subscription.referenceId = 'MySpy';
@@ -730,7 +730,7 @@ describe('openapi Streaming', () => {
 
         it('passes on subscribe calls', () => {
             const streaming = new Streaming(transport, 'testUrl', authProvider);
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             const subscription = mockSubscription();
             subscription.referenceId = 'MySpy';
@@ -744,7 +744,7 @@ describe('openapi Streaming', () => {
 
         it('passes options on modify', () => {
             const streaming = new Streaming(transport, 'testUrl', authProvider);
-            stateChangedCallback({ newState: 1 /* connected */});
+            stateChangedCallback({ newState: 1 /* connected */ });
 
             const subscription = mockSubscription();
             subscription.referenceId = 'MySpy';

--- a/src/openapi/streaming/streaming.spec.js
+++ b/src/openapi/streaming/streaming.spec.js
@@ -1,7 +1,7 @@
 import { installClock, uninstallClock, tick, setTimeout } from '../../test/utils';
 import mockTransport from '../../test/mocks/transport';
 import '../../test/mocks/math-random';
-import Streaming from './streaming';
+import Streaming, { findRetryDelay } from './streaming';
 import log from '../../log';
 
 describe('openapi Streaming', () => {
@@ -87,6 +87,106 @@ describe('openapi Streaming', () => {
             expect(global.$.connection.mock.calls.length).toEqual(1);
             expect(global.$.connection.mock.calls[0]).toEqual(['testUrl/streaming/connection']);
             expect(streaming.getQuery()).toEqual('authorization=TOKEN&context=0000000000');
+        });
+    });
+
+    describe('findRetryDelay', () => {
+        it('find delay for level 0', () => {
+            const mockedLevels = [
+                { level: 0, delay: 1000 },
+                { level: 1, delay: 2000 },
+                { level: 5, delay: 5000 },
+            ];
+
+            const defaultDelay = 500;
+            const result = findRetryDelay(mockedLevels, 0, defaultDelay);
+
+            expect(result).toBe(1000);
+        });
+
+        it('find delay for level 1', () => {
+            const mockedLevels = [
+                { level: 0, delay: 1000 },
+                { level: 1, delay: 2000 },
+                { level: 5, delay: 5000 },
+            ];
+
+            const defaultDelay = 500;
+            const result = findRetryDelay(mockedLevels, 1, defaultDelay);
+
+            expect(result).toBe(2000);
+        });
+
+        it('find delay for level 4 in between two setup levels', () => {
+            const mockedLevels = [
+                { level: 0, delay: 1000 },
+                { level: 1, delay: 2000 },
+                { level: 5, delay: 5000 },
+            ];
+
+            const defaultDelay = 500;
+            const result = findRetryDelay(mockedLevels, 4, defaultDelay);
+
+            expect(result).toBe(2000);
+        });
+
+        it('find delay for level 5', () => {
+            const mockedLevels = [
+                { level: 0, delay: 1000 },
+                { level: 1, delay: 2000 },
+                { level: 5, delay: 5000 },
+            ];
+
+            const defaultDelay = 500;
+            const result = findRetryDelay(mockedLevels, 5, defaultDelay);
+
+            expect(result).toBe(5000);
+        });
+
+        it('find delay for retry index of 6', () => {
+            const mockedLevels = [
+                { level: 0, delay: 1000 },
+                { level: 1, delay: 2000 },
+                { level: 5, delay: 5000 },
+            ];
+
+            const defaultDelay = 500;
+            const result = findRetryDelay(mockedLevels, 6, defaultDelay);
+
+            expect(result).toBe(5000);
+        });
+
+        it('find delay for retry index of 100', () => {
+            const mockedLevels = [
+                { level: 0, delay: 1000 },
+                { level: 1, delay: 2000 },
+                { level: 5, delay: 5000 },
+            ];
+
+            const defaultDelay = 500;
+            const result = findRetryDelay(mockedLevels, 100, defaultDelay);
+
+            expect(result).toBe(5000);
+        });
+
+        it('return default delay if list of levels is empty', () => {
+            const mockedLevels = [];
+
+            const defaultDelay = 500;
+            const result = findRetryDelay(mockedLevels, 0, defaultDelay);
+
+            expect(result).toBe(500);
+        });
+
+        it('return default delay if list of levels is missing specific level', () => {
+            const mockedLevels = [
+                { level: 2, delay: 5000 },
+            ];
+
+            const defaultDelay = 500;
+            const result = findRetryDelay(mockedLevels, 0, defaultDelay);
+
+            expect(result).toBe(500);
         });
     });
 
@@ -279,6 +379,122 @@ describe('openapi Streaming', () => {
             expect(subscription.reset.mock.calls[0]).toEqual([]);
 
             expect(subscription.streamingContextId).toEqual('0060000000');
+            expect(subscription.streamingContextId).toEqual(streaming.contextId);
+        });
+
+        it('if signal-r disconnects, when retry levels are provided but missing for specific retry, use connectRetryDelay', () => {
+            const mockRetryLevels = [
+                { level: 1, delay: 2500 },
+            ];
+            const connectRetryDelay = 9000;
+
+            givenStreaming({ connectRetryDelayLevels: mockRetryLevels, connectRetryDelay });
+            stateChangedCallback({ newState: 0 /* connecting */});
+            stateChangedCallback({ newState: 1 /* connected */});
+
+            // First disconnect
+            stateChangedCallback({ newState: 4 /* disconnected */});
+
+            expect(subscription.streamingContextId).toEqual('0000000000');
+            expect(subscription.streamingContextId).toEqual(streaming.contextId);
+
+            tick(9000);
+
+            expect(mockConnection.start.mock.calls.length).toEqual(2);
+            stateChangedCallback({ newState: 0 /* connecting */});
+            stateChangedCallback({ newState: 1 /* connected */});
+
+            expect(subscription.streamingContextId).toEqual('0000900000');
+            expect(subscription.streamingContextId).toEqual(streaming.contextId);
+        });
+
+        it('if signal-r disconnects, when retry levels are provided but empty, use connectRetryDelay', () => {
+            const mockRetryLevels = [];
+            const connectRetryDelay = 7500;
+
+            givenStreaming({ connectRetryDelayLevels: mockRetryLevels, connectRetryDelay });
+            stateChangedCallback({ newState: 0 /* connecting */});
+            stateChangedCallback({ newState: 1 /* connected */});
+
+            // First disconnect
+            stateChangedCallback({ newState: 4 /* disconnected */});
+
+            expect(subscription.streamingContextId).toEqual('0000000000');
+            expect(subscription.streamingContextId).toEqual(streaming.contextId);
+
+            tick(7500);
+
+            expect(mockConnection.start.mock.calls.length).toEqual(2);
+            stateChangedCallback({ newState: 0 /* connecting */});
+            stateChangedCallback({ newState: 1 /* connected */});
+
+            expect(subscription.streamingContextId).toEqual('0000750000');
+            expect(subscription.streamingContextId).toEqual(streaming.contextId);
+        });
+
+        it('if signal-r disconnects, it tries to reconnect using defined retry levels', () => {
+            const mockRetryLevels = [
+                { level: 0, delay: 2500 },
+                { level: 1, delay: 5000 },
+                { level: 2, delay: 7000 },
+            ];
+
+            givenStreaming({ connectRetryDelayLevels: mockRetryLevels });
+            stateChangedCallback({ newState: 0 /* connecting */});
+            stateChangedCallback({ newState: 1 /* connected */});
+
+            // First disconnect
+            stateChangedCallback({ newState: 4 /* disconnected */});
+
+            expect(subscription.streamingContextId).toEqual('0000000000');
+            expect(subscription.streamingContextId).toEqual(streaming.contextId);
+
+            tick(2500);
+
+            expect(mockConnection.start.mock.calls.length).toEqual(2);
+            stateChangedCallback({ newState: 0 /* connecting */});
+            stateChangedCallback({ newState: 1 /* connected */});
+
+            expect(subscription.streamingContextId).toEqual('0000250000');
+            expect(subscription.streamingContextId).toEqual(streaming.contextId);
+
+            // Second disconnect
+
+            stateChangedCallback({ newState: 4 /* disconnected */});
+
+            tick(5000);
+
+            expect(mockConnection.start.mock.calls.length).toEqual(3);
+            stateChangedCallback({ newState: 0 /* connecting */});
+            stateChangedCallback({ newState: 1 /* connected */});
+
+            expect(subscription.streamingContextId).toEqual('0000750000');
+            expect(subscription.streamingContextId).toEqual(streaming.contextId);
+
+            // Third disconnect
+
+            stateChangedCallback({ newState: 4 /* disconnected */});
+
+            tick(7000);
+
+            expect(mockConnection.start.mock.calls.length).toEqual(4);
+            stateChangedCallback({ newState: 0 /* connecting */});
+            stateChangedCallback({ newState: 1 /* connected */});
+
+            expect(subscription.streamingContextId).toEqual('0001450000');
+            expect(subscription.streamingContextId).toEqual(streaming.contextId);
+
+            // Forth disconnect
+
+            stateChangedCallback({ newState: 4 /* disconnected */});
+
+            tick(7000);
+
+            expect(mockConnection.start.mock.calls.length).toEqual(5);
+            stateChangedCallback({ newState: 0 /* connecting */});
+            stateChangedCallback({ newState: 1 /* connected */});
+
+            expect(subscription.streamingContextId).toEqual('0002150000');
             expect(subscription.streamingContextId).toEqual(streaming.contextId);
         });
     });


### PR DESCRIPTION
Add delay levels for streaming total reconnects.
Allows client to provide various delay levels for specific retry counts levels. 

Example Structure and documented side effects on delays:
```
[
   { level: 0, delay: 1000 }, // First reconnect will wait 1s.
   { level: 1, delay: 2000 }, // Second reconnect will wait 2s.
   { level: 5, delay: 3000 }, // From second reconnect to 4th one, we will use 2s delay, and from 5th up to infinity, 3s delay would be used.
]
```