### PR TITLE
Set default value for retryCount

### DIFF
--- a/src/openapi/streaming/streaming.js
+++ b/src/openapi/streaming/streaming.js
@@ -521,6 +521,7 @@ function removeSubscription(subscription) {
 function Streaming(transport, baseUrl, authProvider, options) {
     emitter.mixinTo(this);
 
+    this.retryCount = 0;
     this.connectionState = this.CONNECTION_STATE_INITIALIZING;
     this.baseUrl = baseUrl;
     this.authProvider = authProvider;

--- a/src/openapi/streaming/streaming.spec.js
+++ b/src/openapi/streaming/streaming.spec.js
@@ -224,6 +224,7 @@ describe('openapi Streaming', () => {
 
         it('is initially initialising', () => {
             streaming = new Streaming(transport, 'testUrl', authProvider);
+            expect(streaming.retryCount).toBe(0);
             expect(streaming.connectionState).toEqual(streaming.CONNECTION_STATE_INITIALIZING);
         });
 


### PR DESCRIPTION
Set default value for retryCount. Otherwise it's possible it will have NaN value forever, even after increments.