### PR TITLE
Fix websocket transport

### DIFF
--- a/src/openapi/streaming/connection/transport/websocket-transport.js
+++ b/src/openapi/streaming/connection/transport/websocket-transport.js
@@ -165,7 +165,6 @@ function handleSocketOpen() {
 
         log.debug(LOG_AREA, 'Socket opened');
         this.stateChangedCallback(constants.CONNECTION_STATE_CONNECTED);
-        this.startedCallback();
     }
 }
 
@@ -363,8 +362,8 @@ WebsocketTransport.prototype.start = function(options, callback) {
     const authorizePromise = this.getAuthorizePromise(this.contextId);
 
     authorizePromise.then(() => {
+        this.startedCallback();
         this.stateChangedCallback(constants.CONNECTION_STATE_CONNECTING);
-        
         connect.call(this);
     });
 };

--- a/src/openapi/streaming/connection/transport/websocket-transport.js
+++ b/src/openapi/streaming/connection/transport/websocket-transport.js
@@ -153,8 +153,8 @@ function parseMessage(rawData) {
  * @param { Object } error - The error object with message property.
  */
 function handleFailure(error) {
+    disconnect.call(this);
     this.stateChangedCallback(constants.CONNECTION_STATE_FAILED);
-    this.destroy();
     this.failCallback(error);
 }
 
@@ -194,7 +194,7 @@ function handleSocketClose(event) {
     }
 
     if (!this.hasWorked) {
-        handleFailure({
+        handleFailure.call(this, {
             message: `websocket error occured. code: ${event.code}, reason: ${event.reason}`,
         });
 
@@ -345,7 +345,9 @@ WebsocketTransport.prototype.start = function(options, callback) {
     this.startedCallback = callback || NOOP;
 
     if (!this.isSupported()) {
-        handleFailure({ message: 'WebSocket Transport is not supported.' });
+        handleFailure.call(this, {
+            message: 'WebSocket Transport is not supported.',
+        });
         return;
     }
 

--- a/src/openapi/streaming/connection/transport/websocket-transport.js
+++ b/src/openapi/streaming/connection/transport/websocket-transport.js
@@ -16,7 +16,7 @@ const NAME = 'plainWebSockets';
 const socketCloseCodes = {
     NORMAL_CLOSURE: 1000,
     TOKEN_EXPIRED: 1002,
-}
+};
 
 const CLOSE_REASON_DESTROY = 'Normal Close due to connection destroy action';
 
@@ -45,7 +45,7 @@ function connect() {
         socket.onopen = handleSocketOpen.bind(this);
         socket.onmessage = handleSocketMessage.bind(this);
         socket.onclose = handleSocketClose.bind(this);
-        
+
         this.socket = socket;
     } catch (error) {
         handleFailure.call(this, {
@@ -219,8 +219,6 @@ function handleSocketClose(event) {
     reconnect.call(this);
 }
 
-
-
 // -- Exported methods section --
 
 /**
@@ -355,7 +353,6 @@ WebsocketTransport.prototype.start = function(options, callback) {
         log.debug(LOG_AREA, 'only one socket per connection is allowed');
         return;
     }
-    
 
     log.debug(LOG_AREA, 'Starting transport');
 
@@ -378,7 +375,7 @@ WebsocketTransport.prototype.stop = function() {
     this.authorizePromis = null;
     this.reconnectCount = 0;
     this.hasWorked = false;
-    
+
     this.stateChangedCallback(constants.CONNECTION_STATE_DISCONNECTED);
 };
 

--- a/src/openapi/streaming/connection/transport/websocket-transport.spec.js
+++ b/src/openapi/streaming/connection/transport/websocket-transport.spec.js
@@ -138,6 +138,7 @@ describe('openapi WebSocket Transport', () => {
         let transport;
         let stateChangedSpy;
         let spyOnStartCallback;
+        let unauthorizedCallbackStub;
 
         function givenTransport(options) {
             spyOnStartCallback = jest.fn().mockName('spyStartCallback');
@@ -150,10 +151,13 @@ describe('openapi WebSocket Transport', () => {
             transport.start(options, spyOnStartCallback);
             stateChangedSpy = jest.fn().mockName('stateChanged');
             transport.setStateChangedCallback(stateChangedSpy);
+            
+            unauthorizedCallbackStub = jest.fn().mockImplementation(() => transport.updateQuery(AUTH_TOKEN, CONTEXT_ID, true));
+            transport.setUnauthorizedCallback(unauthorizedCallbackStub);
             return transport;
         }
 
-        it('should call stateChanged callback with connecting state when internal signalR state changed to connecting', (done) => {
+        it('should call stateChanged callback with connecting state when internal state changed to connecting', (done) => {
             givenTransport();
 
             transport.authorizePromise.then(() => {
@@ -165,7 +169,7 @@ describe('openapi WebSocket Transport', () => {
             });
         });
 
-        it('should call stateChanged callback with connected state when internal signalR state changed to connected', (done) => {
+        it('should call stateChanged callback with connected state when internal state changed to connected', (done) => {
             givenTransport();
 
             transport.authorizePromise.then(() => {
@@ -186,7 +190,7 @@ describe('openapi WebSocket Transport', () => {
             });
         });
 
-        it.only('should call stateChanged callback with disconnected state when internal signalR state changed to disconnected and reconnect', (done) => {
+        it('should call stateChanged callback with reconnecting state when internal state changed to reconnect', (done) => {
             givenTransport();
 
             const initialPromise = transport.authorizePromise;
@@ -208,9 +212,6 @@ describe('openapi WebSocket Transport', () => {
                 transport.socket.onclose({ code: 1001 });
 
                 expect(stateChangedSpy.mock.calls[2]).toEqual([
-                    constants.CONNECTION_STATE_DISCONNECTED,
-                ]);
-                expect(stateChangedSpy.mock.calls[3]).toEqual([
                     constants.CONNECTION_STATE_RECONNECTING,
                 ]);
 
@@ -223,7 +224,7 @@ describe('openapi WebSocket Transport', () => {
             });
         });
 
-        it.only('should reconnect with a new authorization when it gets a possible 401', (done) => {
+        it('should reconnect with a new authorization when it gets a possible 401', (done) => {
             givenTransport();
 
             const initialPromise = transport.authorizePromise;
@@ -242,12 +243,9 @@ describe('openapi WebSocket Transport', () => {
                 ]);
 
                 transport.socket.readyState = 3; // WebSocket internal state equal closed
-                transport.socket.onclose({ code: 1006 });
+                transport.socket.onclose({ code: 1002 });
 
                 expect(stateChangedSpy.mock.calls[2]).toEqual([
-                    constants.CONNECTION_STATE_DISCONNECTED,
-                ]);
-                expect(stateChangedSpy.mock.calls[3]).toEqual([
                     constants.CONNECTION_STATE_RECONNECTING,
                 ]);
 

--- a/src/openapi/streaming/connection/transport/websocket-transport.spec.js
+++ b/src/openapi/streaming/connection/transport/websocket-transport.spec.js
@@ -151,8 +151,12 @@ describe('openapi WebSocket Transport', () => {
             transport.start(options, spyOnStartCallback);
             stateChangedSpy = jest.fn().mockName('stateChanged');
             transport.setStateChangedCallback(stateChangedSpy);
-            
-            unauthorizedCallbackStub = jest.fn().mockImplementation(() => transport.updateQuery(AUTH_TOKEN, CONTEXT_ID, true));
+
+            unauthorizedCallbackStub = jest
+                .fn()
+                .mockImplementation(() =>
+                    transport.updateQuery(AUTH_TOKEN, CONTEXT_ID, true),
+                );
             transport.setUnauthorizedCallback(unauthorizedCallbackStub);
             return transport;
         }


### PR DESCRIPTION
Fixes:

- null contextId while reconnecting.

- Fixes reconnection logic. i.e. don't fire disconnect event unless reconnect timeout is over

- Handle 1002 on close. i.e. re-authorise if token expired