### PR TITLE
Revew log messages and improve network resiliency

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+### v7.0.0
+
+- BREAKING - Review all log messages. Most network errors and expected events should not be errors or warnings.
+- BREAKING - Remove maxAuthErrors from TransportAuth - we now detect multiple auth errors on a endpoint intelligently
+- BREAKING - Rename authErrorsCleanupDebounce to authErrorsIgnoreDuration
+- Retry failed attempts to update websocket authentication
+- Added new EVENT_STREAMING_FAILED when a streaming connection completely fails
+- If a request for a subscription is sent twice, unsubscribe from the subscription that the library did not receive a response for
+- If an error occurs processing a protobuf message, we now reset the subscription so it isn't stuck
+
 ### v.6.2.5
 
 - Use fetch instead of openapi transport for authorization

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "6.2.5",
+    "version": "7.0.0",
     "engines": {
         "node": ">=4"
     },

--- a/src/openapi/batch-util.js
+++ b/src/openapi/batch-util.js
@@ -79,11 +79,11 @@ function parse(responseText, parentRequestId = 0) {
                     ) {
                         try {
                             currentData.response = JSON.parse(line);
-                        } catch (ex) {
-                            log.warn(
+                        } catch (error) {
+                            log.error(
                                 LOG_AREA,
-                                'Unexpected exception parsing json. Ignoring.',
-                                ex,
+                                'Unexpected error parsing json',
+                                { error, line, requestId },
                             );
                         }
                     }

--- a/src/openapi/streaming/connection/connection.js
+++ b/src/openapi/streaming/connection/connection.js
@@ -30,7 +30,7 @@ function getLogDetails() {
 }
 
 function onTransportFail(error) {
-    log.error(LOG_AREA, 'Transport failed', {
+    log.info(LOG_AREA, 'Transport failed', {
         error,
         ...getLogDetails.call(this),
     });
@@ -40,15 +40,15 @@ function onTransportFail(error) {
 
     if (!this.transport) {
         // No next transport available. Report total failure.
-        log.error(LOG_AREA, 'Next supported Transport not found', {
+        log.warn(LOG_AREA, 'Next supported Transport not found', {
             error,
             ...getLogDetails.call(this),
         });
-        this.failCallback({ message: 'Next supported Transport not found' });
+        this.failCallback();
         return;
     }
 
-    log.debug(LOG_AREA, 'Next supported Transport found.', {
+    log.debug(LOG_AREA, 'Next supported Transport found', {
         name: this.transport.name,
     });
 
@@ -56,7 +56,6 @@ function onTransportFail(error) {
     this.transport.setStateChangedCallback(this.stateChangedCallback);
     this.transport.setUnauthorizedCallback(this.unauthorizedCallback);
     this.transport.setConnectionSlowCallback(this.connectionSlowCallback);
-    this.transport.setErrorCallback(this.errorCallback);
 
     if (this.state === STATE_STARTED) {
         this.transport.updateQuery(this.authToken, this.contextId);
@@ -117,7 +116,6 @@ function Connection(options, baseUrl, failCallback = NOOP) {
     this.stateChangedCallback = NOOP;
     this.receiveCallback = NOOP;
     this.connectionSlowCallback = NOOP;
-    this.errorCallback = NOOP;
 
     // Parameters
     this.baseUrl = baseUrl;
@@ -142,7 +140,7 @@ function Connection(options, baseUrl, failCallback = NOOP) {
             'Supported Transport not found.',
             getLogDetails.call(this),
         );
-        this.failCallback({ message: 'Unable to setup initial transport.' });
+        throw new Error('Unable to setup initial transport.');
     } else {
         log.debug(LOG_AREA, 'Supported Transport found', {
             name: this.transport.name,
@@ -168,13 +166,6 @@ Connection.prototype.setReceivedCallback = function(callback) {
     if (this.transport) {
         this.receiveCallback = callback;
         this.transport.setReceivedCallback(callback);
-    }
-};
-
-Connection.prototype.setErrorCallback = function(callback) {
-    if (this.transport) {
-        this.errorCallback = callback;
-        this.transport.setErrorCallback(callback);
     }
 };
 

--- a/src/openapi/streaming/connection/connection.js
+++ b/src/openapi/streaming/connection/connection.js
@@ -217,6 +217,18 @@ Connection.prototype.getQuery = function() {
     }
 };
 
+Connection.prototype.onOrphanFound = function() {
+    if (this.transport && this.transport.onOrphanFound) {
+        this.transport.onOrphanFound();
+    }
+};
+
+Connection.prototype.onSubscribeNetworkError = function() {
+    if (this.transport && this.transport.onSubscribeNetworkError) {
+        this.transport.onSubscribeNetworkError();
+    }
+};
+
 /**
  * Get underlying transport
  * @returns {*}

--- a/src/openapi/streaming/connection/constants.js
+++ b/src/openapi/streaming/connection/constants.js
@@ -6,6 +6,10 @@ export const EVENT_CONNECTION_STATE_CHANGED = 'connectionStateChanged';
  * Event that occurs when the connection is slow.
  */
 export const EVENT_CONNECTION_SLOW = 'connectionSlow';
+/**
+ * Event that occurs when the connection fails.
+ */
+export const EVENT_STREAMING_FAILED = 'streamingFailed';
 
 /**
  * Streaming has been created but has not yet started the connection.

--- a/src/openapi/streaming/connection/transport/signalr-transport.js
+++ b/src/openapi/streaming/connection/transport/signalr-transport.js
@@ -23,7 +23,7 @@ function mapConnectionState(state) {
             return constants.CONNECTION_STATE_RECONNECTING;
 
         default:
-            log.warn(LOG_AREA, 'unrecognised state', state);
+            log.warn(LOG_AREA, 'Unrecognised state', state);
             break;
     }
 
@@ -36,16 +36,13 @@ function mapConnectionState(state) {
  * signal-r attempts to keep the subscription and if it doesn't we will get the normal failed events
  */
 function handleError(errorDetail) {
-    log.error(LOG_AREA, 'Transport error', errorDetail);
+    log.warn(LOG_AREA, 'Transport error', errorDetail);
     if (
         errorDetail &&
         errorDetail.source &&
         errorDetail.source.status === 401
     ) {
         this.unauthorizedCallback();
-    }
-    if (typeof this.errorCallback === 'function') {
-        this.errorCallback(errorDetail);
     }
 }
 
@@ -54,7 +51,7 @@ function handleError(errorDetail) {
  * @param message
  */
 function handleLog(message) {
-    log.debug(LOG_AREA, message);
+    log.debug(LOG_AREA, message.replace(/BEARER[^&]+/i, '[Redacted Token]'));
 }
 
 function handleStateChanged(payload) {
@@ -68,14 +65,13 @@ function handleStateChanged(payload) {
 /**
  * SignalR Transport which supports both webSocket and longPolling with internal fallback mechanism.
  */
-function SignalrTransport(baseUrl) {
+function SignalrTransport(baseUrl, failCallback) {
     this.name = NAME;
     this.baseUrl = baseUrl;
     this.connectionUrl = `${baseUrl}/streaming/connection`;
     this.connection = $.connection(this.connectionUrl);
     this.transport = null;
     this.stateChangedCallback = NOOP;
-    this.errorCallback = NOOP;
     this.unauthorizedCallback = NOOP;
     this.connection.stateChanged(handleStateChanged.bind(this));
     this.connection.log = handleLog.bind(this);
@@ -100,10 +96,6 @@ SignalrTransport.prototype.setStateChangedCallback = function(callback) {
 
 SignalrTransport.prototype.setReceivedCallback = function(callback) {
     this.connection.received(callback);
-};
-
-SignalrTransport.prototype.setErrorCallback = function(callback) {
-    this.errorCallback = callback;
 };
 
 SignalrTransport.prototype.setConnectionSlowCallback = function(callback) {

--- a/src/openapi/streaming/connection/transport/signalr-transport.spec.js
+++ b/src/openapi/streaming/connection/transport/signalr-transport.spec.js
@@ -171,9 +171,9 @@ describe('openapi SignalR Transport', () => {
             expect(connectionSlowSpy.mock.calls.length).toEqual(1);
         });
         it('handles connection error events', () => {
-            jest.spyOn(log, 'error');
+            jest.spyOn(log, 'warn');
             errorCallback('error details');
-            expect(log.error.mock.calls.length).toEqual(1);
+            expect(log.warn.mock.calls.length).toEqual(1);
         });
         it('handles signal-r log calls', () => {
             jest.spyOn(log, 'debug');

--- a/src/openapi/streaming/connection/transport/websocket-transport.spec.js
+++ b/src/openapi/streaming/connection/transport/websocket-transport.spec.js
@@ -170,12 +170,7 @@ describe('openapi WebSocket Transport', () => {
 
                 transport.socket.onmessage({ data: payload.buffer });
                 expect(spyOnFailCallback).toBeCalledTimes(1);
-                expect(spyOnFailCallback).toBeCalledWith(
-                    expect.objectContaining({
-                        payload: illFormattedJson,
-                        payloadSize: 13,
-                    }),
-                );
+
                 done();
             });
         });

--- a/src/openapi/streaming/connection/transport/websocket-transport.spec.js
+++ b/src/openapi/streaming/connection/transport/websocket-transport.spec.js
@@ -1,9 +1,15 @@
-import { installClock, uninstallClock, tick } from '../../../../test/utils';
+import {
+    installClock,
+    uninstallClock,
+    tick,
+    setTimeout,
+} from '../../../../test/utils';
 import '../../../../test/mocks/math-random';
 import mockFetch from '../../../../test/mocks/fetch';
 import WebSocketTransport from './websocket-transport';
 import * as constants from './../constants';
 import jsonPayload from './payload.json';
+import * as RequestUtils from '../../../../utils/request';
 
 const CONTEXT_ID = '0000000000';
 const AUTH_TOKEN = 'TOKEN';
@@ -29,6 +35,8 @@ describe('openapi WebSocket Transport', () => {
             on: jest.fn(),
         };
         authProvider.getToken.mockImplementation(() => 'TOKEN');
+
+        RequestUtils.resetCounter();
 
         installClock();
     });
@@ -101,6 +109,104 @@ describe('openapi WebSocket Transport', () => {
                 '?contextId=0000000000&Authorization=TOKEN',
             );
         });
+    });
+
+    describe('network errors', () => {
+        it('should retry authorization when it gets a network error', (done) => {
+            const options = {};
+            const spyOnStartCallback = jest.fn().mockName('spyStartCallback');
+
+            const transport = new WebSocketTransport(BASE_URL);
+            transport.updateQuery(AUTH_TOKEN, CONTEXT_ID);
+            transport.start(options, spyOnStartCallback);
+
+            expect(fetchMock).toBeCalledTimes(1);
+            expect(fetchMock).toBeCalledWith(
+                'testUrl/streamingws/authorize?contextId=0000000000',
+                expect.objectContaining({
+                    headers: { 'X-Request-Id': 1, Authorization: 'TOKEN' },
+                }),
+            );
+            fetchMock.mockClear();
+
+            fetchMock.reject(new Error('network error'));
+            tick(1);
+
+            setTimeout(() => {
+                expect(fetchMock).toBeCalledTimes(1);
+                expect(fetchMock).toBeCalledWith(
+                    'testUrl/streamingws/authorize?contextId=0000000000',
+                    expect.objectContaining({
+                        headers: { 'X-Request-Id': 2, Authorization: 'TOKEN' },
+                    }),
+                );
+                fetchMock.resolve(200, {});
+
+                setTimeout(() => {
+                    expect(spyOnStartCallback).toBeCalledTimes(1);
+
+                    done();
+                });
+            });
+        });
+
+        it.each([
+            [5001, 0, true],
+            [2000, 3001, true],
+            [0, 0, false],
+            [4000, 500, false],
+        ])(
+            'should reconnect if it looks like we are not connected any more - %d,% d',
+            (timeAfterMsg, timeAfterOrphanFound, shouldReconnect, done) => {
+                const options = {};
+                const spyOnStartCallback = jest
+                    .fn()
+                    .mockName('spyStartCallback');
+
+                const transport = new WebSocketTransport(BASE_URL);
+                transport.updateQuery(AUTH_TOKEN, CONTEXT_ID);
+                transport.start(options, spyOnStartCallback);
+                fetchMock.resolve(200, {});
+
+                setTimeout(() => {
+                    const originalSocket = transport.socket;
+
+                    // we get data
+                    const dataBuffer = new window.TextEncoder().encode(
+                        JSON.stringify(jsonPayload),
+                    );
+                    const payload = new Uint8Array(dataBuffer.length + 17);
+                    payload.set(
+                        [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 56, 0, 134, 12, 0, 0],
+                        0,
+                    );
+                    payload.set(dataBuffer, 17);
+
+                    transport.socket.onmessage({ data: payload.buffer });
+
+                    // but now its disconnected.. 5 seconds pass
+                    tick(timeAfterMsg);
+
+                    // a orphan is found
+                    transport.onOrphanFound();
+
+                    tick(timeAfterOrphanFound);
+
+                    expect(transport.socket).toBe(originalSocket);
+
+                    transport.onSubscribeNetworkError();
+
+                    if (shouldReconnect) {
+                        expect(transport.socket).not.toBe(originalSocket);
+                        expect(transport.socket).not.toBeNull();
+                    } else {
+                        expect(transport.socket).toBe(originalSocket);
+                    }
+
+                    done();
+                });
+            },
+        );
     });
 
     describe('received', () => {

--- a/src/openapi/streaming/orphan-finder.js
+++ b/src/openapi/streaming/orphan-finder.js
@@ -76,9 +76,9 @@ StreamingOrphanFinder.prototype.update = function() {
     // if this update is running very late then the chances are the phone is in background mode
     // or has just come out of it. If so, we delay checking
     if (oldNextUpdateIn < -MAX_UPDATE_DELAY) {
-        log.warn(
+        log.info(
             LOG_AREA,
-            'update occurred much later than requested, assuming wake from sleep and will retry',
+            'Update occurred much later than requested, assuming wake from sleep and will retry',
             oldNextUpdateIn,
         );
 

--- a/src/openapi/streaming/streaming-websocket.spec.js
+++ b/src/openapi/streaming/streaming-websocket.spec.js
@@ -27,7 +27,6 @@ describe('openapi Streaming', () => {
     let connectionSlowCallback;
     let startCallback;
     let receivedCallback;
-    let errorCallback;
     let authProvider;
     let mockConnection;
     let subscriptionUpdateSpy;
@@ -57,9 +56,6 @@ describe('openapi Streaming', () => {
         mockConnection.received.mockImplementation((callback) => {
             receivedCallback = callback;
         });
-        mockConnection.error.mockImplementation((callback) => {
-            errorCallback = callback;
-        });
         mockConnection.connectionSlow.mockImplementation((callback) => {
             connectionSlowCallback = callback;
         });
@@ -85,10 +81,6 @@ describe('openapi Streaming', () => {
                 connectionSlowCallback = callback;
             },
         );
-
-        Connection.prototype.setErrorCallback.mockImplementation((callback) => {
-            errorCallback = callback;
-        });
 
         global.$ = {
             connection: jest.fn().mockReturnValue(mockConnection),
@@ -537,11 +529,6 @@ describe('openapi Streaming', () => {
             streaming.on(streaming.EVENT_CONNECTION_SLOW, connectionSlowSpy);
             connectionSlowCallback();
             expect(connectionSlowSpy.mock.calls.length).toEqual(1);
-        });
-        it('handles connection error events', () => {
-            jest.spyOn(log, 'error');
-            errorCallback('error details');
-            expect(log.error.mock.calls.length).toEqual(1);
         });
     });
 

--- a/src/openapi/streaming/streaming.js
+++ b/src/openapi/streaming/streaming.js
@@ -459,6 +459,7 @@ function onOrphanFound(subscription) {
         'Subscription has become orphaned - resetting',
         subscription,
     );
+    this.connection.onOrphanFound();
     subscription.reset();
 }
 
@@ -571,6 +572,10 @@ function removeSubscription(subscription) {
     if (indexOfSubscription >= 0) {
         this.subscriptions.splice(indexOfSubscription, 1);
     }
+}
+
+function onSubscribeNetworkError() {
+    this.connection.onSubscribeNetworkError();
 }
 
 // -- Exported methods section --
@@ -735,6 +740,10 @@ Streaming.prototype.createSubscription = function(
         // Set default format, if target format is not supported.
         normalizedSubscriptionArgs.Format = ParserFacade.getDefaultFormat();
     }
+
+    options = extend({
+        onNetworkError: onSubscribeNetworkError.bind(this),
+    }, options);
 
     const subscription = new Subscription(
         this.contextId,

--- a/src/openapi/streaming/streaming.js
+++ b/src/openapi/streaming/streaming.js
@@ -741,9 +741,12 @@ Streaming.prototype.createSubscription = function(
         normalizedSubscriptionArgs.Format = ParserFacade.getDefaultFormat();
     }
 
-    options = extend({
-        onNetworkError: onSubscribeNetworkError.bind(this),
-    }, options);
+    options = extend(
+        {
+            onNetworkError: onSubscribeNetworkError.bind(this),
+        },
+        options,
+    );
 
     const subscription = new Subscription(
         this.contextId,

--- a/src/openapi/streaming/streaming.spec.js
+++ b/src/openapi/streaming/streaming.spec.js
@@ -705,11 +705,10 @@ describe('openapi Streaming', () => {
             expect(connectionSlowSpy.mock.calls.length).toEqual(1);
         });
         it('handles connection error events', () => {
-            jest.spyOn(log, 'error');
+            jest.spyOn(log, 'warn');
             errorCallback('error details');
 
-            // One error from transport and second error from streaming.
-            expect(log.error.mock.calls.length).toEqual(2);
+            expect(log.warn.mock.calls.length).toEqual(1);
         });
         it('handles signal-r log calls', () => {
             jest.spyOn(log, 'debug');

--- a/src/openapi/streaming/streaming.spec.js
+++ b/src/openapi/streaming/streaming.spec.js
@@ -114,6 +114,34 @@ describe('openapi Streaming', () => {
         });
     });
 
+    describe('network issues', () => {
+        it('calls through', () => {
+            // these calls are ignored for signal-r
+            const streaming = new Streaming(
+                transport,
+                'testUrl',
+                authProvider,
+                {},
+            );
+
+            const subscription = streaming.createSubscription(
+                'root',
+                '/test/test',
+                {},
+                subscriptionUpdateSpy,
+                subscriptionErrorSpy,
+            );
+
+            expect(() => {
+                subscription.onNetworkError();
+            }).not.toThrow();
+
+            expect(() => {
+                streaming.orphanFinder.onOrphanFound(subscription);
+            }).not.toThrow();
+        });
+    });
+
     describe('findRetryDelay', () => {
         it('find delay for level 0', () => {
             const mockedLevels = [

--- a/src/openapi/transport/auth.js
+++ b/src/openapi/transport/auth.js
@@ -38,21 +38,21 @@ function makeTransportMethod(method) {
     };
 }
 
-function onErrorCleanupTimeout() {
-    this.authorizationErrorCount = {};
-    this.errorCleanupTimoutId = null;
-}
-
 function onTransportError(oldTokenExpiry, result) {
     if (result && result.status === 401) {
-        const urlErrorCount = this.getUrlErrorCount(result.url);
+        this.addAuthError(result.url, oldTokenExpiry);
+        this.cleanupAuthErrors();
+        const areUrlAuthErrorsProblematic = this.areUrlAuthErrorsProblematic(
+            result.url,
+            oldTokenExpiry,
+        );
 
-        if (urlErrorCount >= this.maxAuthErrors) {
+        if (areUrlAuthErrorsProblematic) {
             // Blocking infinite loop of authorization re-requests which might be caused by invalid
             // behaviour of given endpoint which constantly returns 401 error.
             log.error(
                 LOG_AREA,
-                'Too many authorization errors occurred within specified timeframe for specific endpoint.',
+                'Too many authorization errors occurred within specified timeframe for specific endpoint',
                 result.url,
             );
             return;
@@ -60,8 +60,6 @@ function onTransportError(oldTokenExpiry, result) {
 
         log.debug(LOG_AREA, 'Authentication failure', result);
 
-        this.incrementErrorCounter(result.url);
-        this.debounceErrorCounterCleanup();
         this.authProvider.tokenRejected(oldTokenExpiry);
     }
     throw result;
@@ -82,25 +80,21 @@ function onTransportError(oldTokenExpiry, result) {
  * @param {Object} [options] - Options for auth and for the core transport. See Transport.
  * @param {string} [options.language] - The language sent as a header if not overridden.
  * @param {boolean} [options.defaultCache=true] - Sets the default caching behaviour if not overridden on a call.
- * @param {number} [options.authErrorsCleanupDebounce] - The debounce timeout (in ms) used for clearing of authorization errors count.
- * @param {number} [options.maxAuthErrors] - The maximum number of authorization errors that
- *          can occur for specific endpoint within specific timeframe.
+ * @param {number} [options.authErrorsIgnoreDuration] - The timeout (in ms) used for clearing of authorization errors.
  */
 function TransportAuth(baseUrl, authProvider, options) {
     if (!authProvider) {
         throw new Error('transport auth created without a auth provider');
     }
 
-    this.authErrorsCleanupDebounce =
-        (options && options.authErrorsCleanupDebounce) ||
+    this.authErrorsIgnoreDuration =
+        (options && options.authErrorsIgnoreDuration) ||
         DEFAULT_AUTH_ERRORS_CLEANUP_DEBOUNCE;
-    this.maxAuthErrors =
-        (options && options.maxAuthErrors) || DEFAULT_MAX_AUTH_ERRORS;
 
     this.transport = new TransportCore(baseUrl, options);
 
     // Map of authorization error counts per endpoint/url.
-    this.authorizationErrorCount = {};
+    this.authorizationErrors = {};
 
     this.authProvider = authProvider;
 }
@@ -155,28 +149,41 @@ TransportAuth.prototype.head = makeTransportMethod('head');
 TransportAuth.prototype.options = makeTransportMethod('options');
 
 /**
- * Run debounced cleanup of error counter map
+ * Cleanup of error counter map
  */
-TransportAuth.prototype.debounceErrorCounterCleanup = function() {
-    if (this.errorCleanupTimoutId) {
-        clearTimeout(this.errorCleanupTimoutId);
-    }
+TransportAuth.prototype.cleanupAuthErrors = function() {
+    const cleanThoseBefore = Date.now() - this.authErrorsIgnoreDuration;
 
-    this.errorCleanupTimoutId = setTimeout(
-        onErrorCleanupTimeout.bind(this),
-        this.authErrorsCleanupDebounce,
-    );
+    for (const url in this.authorizationErrors) {
+        if (this.authorizationErrors.hasOwnProperty(url)) {
+            const newEntries = [];
+            for (let i = 0; i < this.authorizationErrors[url].length; i++) {
+                if (this.authorizationErrors[url][i].added > cleanThoseBefore) {
+                    newEntries.push(this.authorizationErrors[url][i]);
+                }
+            }
+            if (newEntries.length) {
+                this.authorizationErrors[url] = newEntries;
+            } else {
+                delete this.authorizationErrors[url];
+            }
+        }
+    }
 };
 
 /**
- * Increment error counter for specific url/endpoint.
- * @param {string} url - The url/endpoint for which error count is incremented.
+ * Add a authentication error to the error map
+ * @param {string} url - The url/endpoint at which a auth error occurred
+ * @param {number} authExpiry - The expiry of the token that was rejected
  */
-TransportAuth.prototype.incrementErrorCounter = function(url) {
-    if (this.authorizationErrorCount.hasOwnProperty(url)) {
-        this.authorizationErrorCount[url] += 1;
+TransportAuth.prototype.addAuthError = function(url, authExpiry) {
+    if (this.authorizationErrors.hasOwnProperty(url)) {
+        this.authorizationErrors[url].push({
+            authExpiry,
+            added: Date.now(),
+        });
     } else {
-        this.authorizationErrorCount[url] = 1;
+        this.authorizationErrors[url] = [{ authExpiry, added: Date.now() }];
     }
 };
 
@@ -185,12 +192,19 @@ TransportAuth.prototype.incrementErrorCounter = function(url) {
  * @param {string} url - The url/endpoint for which error count is returned.
  * @returns {number} The number of errors
  */
-TransportAuth.prototype.getUrlErrorCount = function(url) {
-    if (this.authorizationErrorCount.hasOwnProperty(url)) {
-        return this.authorizationErrorCount[url];
+TransportAuth.prototype.areUrlAuthErrorsProblematic = function(
+    url,
+    authExpiry,
+) {
+    if (this.authorizationErrors.hasOwnProperty(url)) {
+        for (let i = 0; i < this.authorizationErrors[url].length; i++) {
+            if (this.authorizationErrors[url][i].authExpiry !== authExpiry) {
+                return true;
+            }
+        }
     }
 
-    return 0;
+    return false;
 };
 
 /**
@@ -199,7 +213,7 @@ TransportAuth.prototype.getUrlErrorCount = function(url) {
 TransportAuth.prototype.dispose = function() {
     clearTimeout(this.errorCleanupTimoutId);
     this.errorCleanupTimoutId = null;
-    this.authorizationErrorCount = {};
+    this.authorizationErrors = {};
 
     this.transport.dispose();
 };

--- a/src/openapi/transport/auth.js
+++ b/src/openapi/transport/auth.js
@@ -77,7 +77,8 @@ function onTransportError(oldTokenExpiry, result) {
  * @param {Object} [options] - Options for auth and for the core transport. See Transport.
  * @param {string} [options.language] - The language sent as a header if not overridden.
  * @param {boolean} [options.defaultCache=true] - Sets the default caching behaviour if not overridden on a call.
- * @param {number} [options.authErrorsDebouncePeriod] - The period within which errors on different tokens cause an endpoint auth errors to be ignored.
+ * @param {number} [options.authErrorsDebouncePeriod] - The period within which errors on different tokens cause an endpoint auth errors
+ *                                                      to be ignored.
  */
 function TransportAuth(baseUrl, authProvider, options) {
     if (!authProvider) {

--- a/src/openapi/transport/auth.spec.js
+++ b/src/openapi/transport/auth.spec.js
@@ -439,7 +439,7 @@ describe('openapi TransportAuth', () => {
                     });
                 },
                 () => {
-                    tick(10000);
+                    tick(30001);
 
                     authProvider.getExpiry.mockImplementation(() => 2);
                     transportAuth.post('service_group', 'url').catch(noop);

--- a/src/openapi/transport/putPatchDiagnosticsQueue.js
+++ b/src/openapi/transport/putPatchDiagnosticsQueue.js
@@ -67,11 +67,11 @@ function TransportPutPatchDiagnositicsQueue(transport, transportCore) {
                 transportCore.setUseXHttpMethodOverride(true);
                 log.info(
                     LOG_AREA,
-                    'Diagnostic check for put/patch failed. Fallback to POST used.',
+                    'Diagnostic check for put/patch failed. Fallback to POST used',
                 );
             })
             .then(() => {
-                log.debug(LOG_AREA, 'Diagnostics checks finished, continuing.');
+                log.debug(LOG_AREA, 'Diagnostics checks finished, continuing');
                 this.isQueueing = false;
             }),
     );


### PR DESCRIPTION
I've reviewed all logs - Searching for occurrences of our errors/warns and evaluating whether they should be a error/warning on the basis that error/warns should be indications that something is gone wrong that is abnormal. If a network error occurs or a fairly normal event that isn't a problem occurs, including the effect of a single open api server going down and subscriptions failing over then it should not be a warn/error.