### PR TITLE
Support cloud services

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 node_modules
 libs
 dist
+doc
 output-template.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+doc
 package-lock.json
 libs
 .idea

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-### v.8.0.0
+### v8.0.0
 - BREAKING - Add support for cloud /oapi services. The baseUrl used when constructing transports should no longer include "/openapi"; this is now added by the library.
 
 ### v7.2.1

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v.8.0.0
+- BREAKING - Add support for cloud /oapi services. The baseUrl used when constructing transports should no longer include "/openapi"; this is now added by the library.
+
 ### v7.2.1
 
 - Fix some log messages not passing LOG_AREA and add more details to a parsing error

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "8.0.0-beta.1",
+  "version": "8.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "8.0.0-beta.0",
+  "version": "8.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "7.2.0",
+  "version": "8.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "8.0.0-beta.1",
+    "version": "8.0.0",
     "engines": {
         "node": ">=4"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "7.2.1",
+    "version": "8.0.0-beta.0",
     "engines": {
         "node": ">=4"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "8.0.0-beta.0",
+    "version": "8.0.0-beta.1",
     "engines": {
         "node": ">=4"
     },

--- a/src/openapi/streaming/parser/parser-facade.js
+++ b/src/openapi/streaming/parser/parser-facade.js
@@ -19,14 +19,14 @@ const parsersMap = {};
 
 const defaultParser = ParserJson;
 
-const getId = (format, serviceGroup, url) => {
+const getId = (format, servicePath, url) => {
     if (format === ParserJson.FORMAT_NAME || !format) {
         // Makes sure that all JSON formats share same single parser.
         return ParserJson.FORMAT_NAME;
     }
 
     // Ensures that other formats ie. protobuf, have parser per endpoint.
-    return `${format}.${serviceGroup}.${url}`;
+    return `${format}.${servicePath}.${url}`;
 };
 
 /**
@@ -70,18 +70,18 @@ ParserFacade.isFormatSupported = function(format) {
 };
 
 /**
- * Get parser for given format name, service group and url.
+ * Get parser for given format name, service path and url.
  * Parsers are mapped per name, service and url, to keep schemas per endpoints.
  * Such approach is required as schemas are currently not namespaced and reuse similar message names with different structures.
  * Due to that, we need to keep per endpoint parsers for protobuf parsing type.
  *
  * @param {String} format - The format name. ie. "application/json"
- * @param {String} serviceGroup - The service group
+ * @param {String} servicePath - The service path
  * @param {String} url - The url for given endpoint
  * @return {Object} Parser
  */
-ParserFacade.getParser = function(format, serviceGroup, url) {
-    const id = getId.call(this, format, serviceGroup, url);
+ParserFacade.getParser = function(format, servicePath, url) {
+    const id = getId.call(this, format, servicePath, url);
 
     if (parsersMap[id]) {
         return parsersMap[id];

--- a/src/openapi/streaming/streaming-websocket.spec.js
+++ b/src/openapi/streaming/streaming-websocket.spec.js
@@ -829,14 +829,14 @@ describe('openapi Streaming', () => {
                     .fn()
                     .mockName('onUnsubscribeByTagPending'),
                 url: 'url',
-                serviceGroup: 'serviceGroup',
+                servicePath: 'servicePath',
                 subscriptionData: {
                     Tag: 'tag',
                 },
                 addStateChangedCallback: () => {},
             });
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag');
 
             setTimeout(() => {
                 expect(
@@ -852,14 +852,14 @@ describe('openapi Streaming', () => {
                     .fn()
                     .mockName('onUnsubscribeByTagPending'),
                 url: 'url',
-                serviceGroup: 'serviceGroup',
+                servicePath: 'servicePath',
                 subscriptionData: {
                     Tag: 'tag',
                 },
                 addStateChangedCallback: () => {},
             });
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag2');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag2');
             setTimeout(() => {
                 expect(
                     streaming.subscriptions[0].onUnsubscribeByTagPending,
@@ -874,14 +874,14 @@ describe('openapi Streaming', () => {
                     .fn()
                     .mockName('onUnsubscribeByTagPending'),
                 url: 'url',
-                serviceGroup: 'serviceGroup',
+                servicePath: 'servicePath',
                 subscriptionData: {
                     Tag: 'tag',
                 },
                 addStateChangedCallback: () => {},
             });
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag');
 
             setTimeout(() => {
                 expect(transport.delete).not.toHaveBeenCalled();
@@ -898,7 +898,7 @@ describe('openapi Streaming', () => {
                         .fn()
                         .mockName('onUnsubscribeByTagPending'),
                     url: 'url',
-                    serviceGroup: 'serviceGroup',
+                    servicePath: 'servicePath',
                     subscriptionData: {
                         Tag: 'tag',
                     },
@@ -912,7 +912,7 @@ describe('openapi Streaming', () => {
                         .fn()
                         .mockName('onUnsubscribeByTagPending'),
                     url: 'url',
-                    serviceGroup: 'serviceGroup',
+                    servicePath: 'servicePath',
                     subscriptionData: {
                         Tag: 'tag',
                     },
@@ -921,7 +921,7 @@ describe('openapi Streaming', () => {
                 },
             );
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag');
             subscriptionStateChangedCallback();
 
             setTimeout(() => {
@@ -939,7 +939,7 @@ describe('openapi Streaming', () => {
                         .fn()
                         .mockName('onUnsubscribeByTagPending'),
                     url: 'url',
-                    serviceGroup: 'serviceGroup',
+                    servicePath: 'servicePath',
                     subscriptionData: {
                         Tag: 'tag',
                     },
@@ -957,7 +957,7 @@ describe('openapi Streaming', () => {
                         .fn()
                         .mockName('onUnsubscribeByTagPending'),
                     url: 'url',
-                    serviceGroup: 'serviceGroup',
+                    servicePath: 'servicePath',
                     subscriptionData: {
                         Tag: 'tag',
                     },
@@ -970,7 +970,7 @@ describe('openapi Streaming', () => {
                 },
             );
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag');
             subscriptionStateChangedCallback();
 
             setTimeout(() => {
@@ -990,7 +990,7 @@ describe('openapi Streaming', () => {
                     .fn()
                     .mockName('onUnsubscribeByTagPending'),
                 url: 'url',
-                serviceGroup: 'serviceGroup',
+                servicePath: 'servicePath',
                 subscriptionData: {
                     Tag: 'tag',
                 },
@@ -1006,7 +1006,7 @@ describe('openapi Streaming', () => {
                     .mockName('onUnsubscribeByTagComplete'),
             });
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag');
             subscriptionStateChangedCallback();
 
             setTimeout(() => {
@@ -1029,7 +1029,7 @@ describe('openapi Streaming', () => {
                     .fn()
                     .mockName('onUnsubscribeByTagPending'),
                 url: 'url',
-                serviceGroup: 'serviceGroup',
+                servicePath: 'servicePath',
                 subscriptionData: {
                     Tag: 'tag',
                 },
@@ -1045,7 +1045,7 @@ describe('openapi Streaming', () => {
                     .mockName('onUnsubscribeByTagComplete'),
             });
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag');
             subscriptionStateChangedCallback();
 
             setTimeout(() => {

--- a/src/openapi/streaming/streaming.js
+++ b/src/openapi/streaming/streaming.js
@@ -493,14 +493,14 @@ function handleSubscriptionReadyForUnsubscribe(subscriptions, resolve) {
     }
 }
 
-function getSubscriptionsByTag(serviceGroup, url, tag) {
+function getSubscriptionsByTag(servicePath, url, tag) {
     const subscriptionsToRemove = [];
 
     for (let i = 0; i < this.subscriptions.length; i++) {
         const subscription = this.subscriptions[i];
 
         if (
-            subscription.serviceGroup === serviceGroup &&
+            subscription.servicePath === servicePath &&
             subscription.url === url &&
             subscription.subscriptionData.Tag === tag
         ) {
@@ -543,14 +543,14 @@ function getSubscriptionsReadyPromise(
 }
 
 function unsubscribeSubscriptionByTag(
-    serviceGroup,
+    servicePath,
     url,
     tag,
     shouldDisposeSubscription,
 ) {
     const subscriptionsToRemove = getSubscriptionsByTag.call(
         this,
-        serviceGroup,
+        servicePath,
         url,
         tag,
     );
@@ -562,14 +562,14 @@ function unsubscribeSubscriptionByTag(
 
     allSubscriptionsReady.then(() => {
         this.transport
-            .delete(serviceGroup, url + '/{contextId}/?Tag={tag}', {
+            .delete(servicePath, url + '/{contextId}/?Tag={tag}', {
                 contextId: this.contextId,
                 tag,
             })
             .catch((response) =>
                 log.error(LOG_AREA, 'An error occurred unsubscribing by tag', {
                     response,
-                    serviceGroup,
+                    servicePath,
                     url,
                     tag,
                 }),
@@ -701,7 +701,7 @@ Streaming.prototype.READABLE_CONNECTION_STATE_MAP =
 /**
  * Constructs a new subscription to the given resource.
  *
- * @param {string} serviceGroup - The service group e.g. 'trade'
+ * @param {string} servicePath - The service path e.g. 'trade'
  * @param {string} url - The name of the resource to subscribe to, e.g. '/v1/infoprices/subscriptions'.
  * @param {object} subscriptionArgs - Arguments that detail the subscription.
  * @param {number} [subscriptionArgs.RefreshRate=1000] - The data refresh rate (passed to OpenAPI).
@@ -718,7 +718,7 @@ Streaming.prototype.READABLE_CONNECTION_STATE_MAP =
  * @returns {saxo.openapi.StreamingSubscription} A subscription object.
  */
 Streaming.prototype.createSubscription = function(
-    serviceGroup,
+    servicePath,
     url,
     subscriptionArgs,
     options,
@@ -740,7 +740,7 @@ Streaming.prototype.createSubscription = function(
     const subscription = new Subscription(
         this.contextId,
         this.transport,
-        serviceGroup,
+        servicePath,
         url,
         normalizedSubscriptionArgs,
         onSubscriptionCreated.bind(this),
@@ -799,30 +799,26 @@ Streaming.prototype.disposeSubscription = function(subscription) {
 };
 
 /**
- * Makes all subscriptions stop at the given serviceGroup and url with the given tag (can be restarted)
+ * Makes all subscriptions stop at the given servicePath and url with the given tag (can be restarted)
  * See {@link saxo.openapi.Streaming#disposeSubscriptionByTag} for permanently stopping subscriptions by tag.
  *
- * @param {string} serviceGroup - the serviceGroup of the subscriptions to unsubscribe
+ * @param {string} servicePath - the servicePath of the subscriptions to unsubscribe
  * @param {string} url - the url of the subscriptions to unsubscribe
  * @param {string} tag - the tag of the subscriptions to unsubscribe
  */
-Streaming.prototype.unsubscribeByTag = function(serviceGroup, url, tag) {
-    unsubscribeSubscriptionByTag.call(this, serviceGroup, url, tag, false);
+Streaming.prototype.unsubscribeByTag = function(servicePath, url, tag) {
+    unsubscribeSubscriptionByTag.call(this, servicePath, url, tag, false);
 };
 
 /**
- * Disposes all subscriptions at the given serviceGroup and url by tag permanently. They will be stopped and not be able to be started.
+ * Disposes all subscriptions at the given servicePath and url by tag permanently. They will be stopped and not be able to be started.
  *
- * @param {string} serviceGroup - the serviceGroup of the subscriptions to unsubscribe
+ * @param {string} servicePath - the servicePath of the subscriptions to unsubscribe
  * @param {string} url - the url of the subscriptions to unsubscribe
  * @param {string} tag - the tag of the subscriptions to unsubscribe
  */
-Streaming.prototype.disposeSubscriptionByTag = function(
-    serviceGroup,
-    url,
-    tag,
-) {
-    unsubscribeSubscriptionByTag.call(this, serviceGroup, url, tag, true);
+Streaming.prototype.disposeSubscriptionByTag = function(servicePath, url, tag) {
+    unsubscribeSubscriptionByTag.call(this, servicePath, url, tag, true);
 };
 
 /**

--- a/src/openapi/streaming/streaming.js
+++ b/src/openapi/streaming/streaming.js
@@ -799,10 +799,10 @@ Streaming.prototype.disposeSubscription = function(subscription) {
 };
 
 /**
- * Makes all subscriptions stop at the given servicePath and url with the given tag (can be restarted)
+ * Makes all subscriptions stop at the given service path and url with the given tag (can be restarted)
  * See {@link saxo.openapi.Streaming#disposeSubscriptionByTag} for permanently stopping subscriptions by tag.
  *
- * @param {string} servicePath - the servicePath of the subscriptions to unsubscribe
+ * @param {string} servicePath - the service path of the subscriptions to unsubscribe
  * @param {string} url - the url of the subscriptions to unsubscribe
  * @param {string} tag - the tag of the subscriptions to unsubscribe
  */
@@ -811,9 +811,9 @@ Streaming.prototype.unsubscribeByTag = function(servicePath, url, tag) {
 };
 
 /**
- * Disposes all subscriptions at the given servicePath and url by tag permanently. They will be stopped and not be able to be started.
+ * Disposes all subscriptions at the given service path and url by tag permanently. They will be stopped and not be able to be started.
  *
- * @param {string} servicePath - the servicePath of the subscriptions to unsubscribe
+ * @param {string} servicePath - the service path of the subscriptions to unsubscribe
  * @param {string} url - the url of the subscriptions to unsubscribe
  * @param {string} tag - the tag of the subscriptions to unsubscribe
  */

--- a/src/openapi/streaming/streaming.spec.js
+++ b/src/openapi/streaming/streaming.spec.js
@@ -1018,14 +1018,14 @@ describe('openapi Streaming', () => {
                     .fn()
                     .mockName('onUnsubscribeByTagPending'),
                 url: 'url',
-                serviceGroup: 'serviceGroup',
+                servicePath: 'servicePath',
                 subscriptionData: {
                     Tag: 'tag',
                 },
                 addStateChangedCallback: () => {},
             });
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag');
 
             setTimeout(() => {
                 expect(
@@ -1041,14 +1041,14 @@ describe('openapi Streaming', () => {
                     .fn()
                     .mockName('onUnsubscribeByTagPending'),
                 url: 'url',
-                serviceGroup: 'serviceGroup',
+                servicePath: 'servicePath',
                 subscriptionData: {
                     Tag: 'tag',
                 },
                 addStateChangedCallback: () => {},
             });
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag2');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag2');
             setTimeout(() => {
                 expect(
                     streaming.subscriptions[0].onUnsubscribeByTagPending,
@@ -1063,14 +1063,14 @@ describe('openapi Streaming', () => {
                     .fn()
                     .mockName('onUnsubscribeByTagPending'),
                 url: 'url',
-                serviceGroup: 'serviceGroup',
+                servicePath: 'servicePath',
                 subscriptionData: {
                     Tag: 'tag',
                 },
                 addStateChangedCallback: () => {},
             });
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag');
 
             setTimeout(() => {
                 expect(transport.delete).not.toHaveBeenCalled();
@@ -1087,7 +1087,7 @@ describe('openapi Streaming', () => {
                         .fn()
                         .mockName('onUnsubscribeByTagPending'),
                     url: 'url',
-                    serviceGroup: 'serviceGroup',
+                    servicePath: 'servicePath',
                     subscriptionData: {
                         Tag: 'tag',
                     },
@@ -1101,7 +1101,7 @@ describe('openapi Streaming', () => {
                         .fn()
                         .mockName('onUnsubscribeByTagPending'),
                     url: 'url',
-                    serviceGroup: 'serviceGroup',
+                    servicePath: 'servicePath',
                     subscriptionData: {
                         Tag: 'tag',
                     },
@@ -1110,7 +1110,7 @@ describe('openapi Streaming', () => {
                 },
             );
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag');
             subscriptionStateChangedCallback();
 
             setTimeout(() => {
@@ -1128,7 +1128,7 @@ describe('openapi Streaming', () => {
                         .fn()
                         .mockName('onUnsubscribeByTagPending'),
                     url: 'url',
-                    serviceGroup: 'serviceGroup',
+                    servicePath: 'servicePath',
                     subscriptionData: {
                         Tag: 'tag',
                     },
@@ -1146,7 +1146,7 @@ describe('openapi Streaming', () => {
                         .fn()
                         .mockName('onUnsubscribeByTagPending'),
                     url: 'url',
-                    serviceGroup: 'serviceGroup',
+                    servicePath: 'servicePath',
                     subscriptionData: {
                         Tag: 'tag',
                     },
@@ -1159,7 +1159,7 @@ describe('openapi Streaming', () => {
                 },
             );
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag');
             subscriptionStateChangedCallback();
 
             setTimeout(() => {
@@ -1179,7 +1179,7 @@ describe('openapi Streaming', () => {
                     .fn()
                     .mockName('onUnsubscribeByTagPending'),
                 url: 'url',
-                serviceGroup: 'serviceGroup',
+                servicePath: 'servicePath',
                 subscriptionData: {
                     Tag: 'tag',
                 },
@@ -1195,7 +1195,7 @@ describe('openapi Streaming', () => {
                     .mockName('onUnsubscribeByTagComplete'),
             });
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag');
             subscriptionStateChangedCallback();
 
             setTimeout(() => {
@@ -1218,7 +1218,7 @@ describe('openapi Streaming', () => {
                     .fn()
                     .mockName('onUnsubscribeByTagPending'),
                 url: 'url',
-                serviceGroup: 'serviceGroup',
+                servicePath: 'servicePath',
                 subscriptionData: {
                     Tag: 'tag',
                 },
@@ -1234,7 +1234,7 @@ describe('openapi Streaming', () => {
                     .mockName('onUnsubscribeByTagComplete'),
             });
 
-            streaming.unsubscribeByTag('serviceGroup', 'url', 'tag');
+            streaming.unsubscribeByTag('servicePath', 'url', 'tag');
             subscriptionStateChangedCallback();
 
             setTimeout(() => {

--- a/src/openapi/streaming/subscription.js
+++ b/src/openapi/streaming/subscription.js
@@ -722,7 +722,7 @@ Subscription.prototype.processUpdate = function(message, type) {
     } catch (error) {
         log.error(LOG_AREA, 'Error occurred parsing Data', {
             error,
-            serviceGroup: this.serviceGroup,
+            servicePath: this.servicePath,
             url: this.url,
         });
 

--- a/src/openapi/streaming/subscription.js
+++ b/src/openapi/streaming/subscription.js
@@ -82,13 +82,13 @@ function subscribe() {
     normalizeSubscribeData(data);
 
     log.debug(LOG_AREA, 'Posting to create a subscription', {
-        serviceGroup: this.serviceGroup,
+        servicePath: this.servicePath,
         url: subscribeUrl,
     });
     setState.call(this, this.STATE_SUBSCRIBE_REQUESTED);
 
     this.transport
-        .post(this.serviceGroup, subscribeUrl, null, options)
+        .post(this.servicePath, subscribeUrl, null, options)
         .then(onSubscribeSuccess.bind(this, referenceId))
         .catch(onSubscribeError.bind(this, referenceId));
 }
@@ -102,7 +102,7 @@ function unsubscribe() {
     const referenceId = this.referenceId;
 
     this.transport
-        .delete(this.serviceGroup, this.url + '/{contextId}/{referenceId}', {
+        .delete(this.servicePath, this.url + '/{contextId}/{referenceId}', {
             contextId: this.streamingContextId,
             referenceId,
         })
@@ -118,7 +118,7 @@ function modifyPatch(args) {
 
     this.transport
         .patch(
-            this.serviceGroup,
+            this.servicePath,
             this.url + '/{contextId}/{referenceId}',
             {
                 contextId: this.streamingContextId,
@@ -195,7 +195,7 @@ function performAction(queuedAction, isLastQueuedAction) {
                             state: this.currentState,
                             action,
                             url: this.url,
-                            serviceGroup: this.serviceGroup,
+                            servicePath: this.servicePath,
                         },
                     );
             }
@@ -352,7 +352,7 @@ function onSubscribeSuccess(referenceId, result) {
 
 function cleanUpLeftOverSubscription(referenceId) {
     this.transport
-        .delete(this.serviceGroup, this.url + '/{contextId}/{referenceId}', {
+        .delete(this.servicePath, this.url + '/{contextId}/{referenceId}', {
             contextId: this.streamingContextId,
             referenceId,
         })
@@ -393,7 +393,7 @@ function onSubscribeError(referenceId, response) {
         log.error(LOG_AREA, `A duplicate request occurred subscribing`, {
             response,
             url: this.url,
-            serviceGroup: this.serviceGroup,
+            servicePath: this.servicePath,
             ContextId: this.streamingContextId,
             ReferenceId: referenceId,
             subscriptionData: this.subscriptionData,
@@ -426,7 +426,7 @@ function onSubscribeError(referenceId, response) {
         this.subscriptionData.Format = FORMAT_JSON;
         this.parser = ParserFacade.getParser(
             FORMAT_JSON,
-            this.serviceGroup,
+            this.servicePath,
             this.url,
         );
 
@@ -448,7 +448,7 @@ function onSubscribeError(referenceId, response) {
             {
                 response,
                 url: this.url,
-                serviceGroup: this.serviceGroup,
+                servicePath: this.servicePath,
                 ContextId: this.streamingContextId,
                 ReferenceId: referenceId,
                 subscriptionData: this.subscriptionData,
@@ -476,7 +476,7 @@ function onSubscribeError(referenceId, response) {
         log.error(LOG_AREA, `An error occurred subscribing to ${this.url}`, {
             response,
             url: this.url,
-            serviceGroup: this.serviceGroup,
+            servicePath: this.servicePath,
             ContextId: this.streamingContextId,
             ReferenceId: referenceId,
             subscriptionData: this.subscriptionData,
@@ -604,7 +604,7 @@ function setState(state) {
 function Subscription(
     streamingContextId,
     transport,
-    serviceGroup,
+    servicePath,
     url,
     subscriptionArgs,
     onSubscriptionCreated,
@@ -633,14 +633,14 @@ function Subscription(
      */
     this.parser = ParserFacade.getParser(
         subscriptionArgs.Format,
-        serviceGroup,
+        servicePath,
         url,
     );
 
     this.onStateChangedCallbacks = [];
 
     this.transport = transport;
-    this.serviceGroup = serviceGroup;
+    this.servicePath = servicePath;
     this.url = url;
     this.onSubscriptionCreated = onSubscriptionCreated;
     this.subscriptionData = subscriptionArgs;
@@ -752,7 +752,7 @@ Subscription.prototype.processSnapshot = function(response) {
             // In such scenario, falling back to default parser.
             this.parser = ParserFacade.getParser(
                 ParserFacade.getDefaultFormat(),
-                this.serviceGroup,
+                this.servicePath,
                 this.url,
             );
         }
@@ -940,7 +940,7 @@ Subscription.prototype.onStreamingData = function(message) {
             log.error(LOG_AREA, 'Unanticipated state onStreamingData', {
                 currentState: this.currentState,
                 url: this.url,
-                serviceGroup: this.serviceGroup,
+                servicePath: this.servicePath,
             });
     }
 
@@ -957,7 +957,7 @@ Subscription.prototype.onStreamingData = function(message) {
                 },
                 payload: message,
                 url: this.url,
-                serviceGroup: this.serviceGroup,
+                servicePath: this.servicePath,
             },
         );
     }
@@ -972,7 +972,7 @@ Subscription.prototype.onHeartbeat = function() {
         log.debug(
             LOG_AREA,
             'Received heartbeat for a subscription we havent subscribed to yet',
-            { url: this.url, serviceGroup: this.serviceGroup },
+            { url: this.url, servicePath: this.servicePath },
         );
     }
     onActivity.call(this);

--- a/src/openapi/streaming/subscription.spec.js
+++ b/src/openapi/streaming/subscription.spec.js
@@ -58,7 +58,7 @@ describe('openapi StreamingSubscription', () => {
             subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 { RefreshRate: 120 },
             );
@@ -94,7 +94,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 { RefreshRate: 120 },
             );
@@ -102,7 +102,7 @@ describe('openapi StreamingSubscription', () => {
 
             expect(transport.post.mock.calls.length).toEqual(1);
             expect(transport.post.mock.calls[0]).toEqual([
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 null,
                 expect.objectContaining({
@@ -114,7 +114,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 { RefreshRate: 1 },
             );
@@ -122,7 +122,7 @@ describe('openapi StreamingSubscription', () => {
 
             expect(transport.post.mock.calls.length).toEqual(1);
             expect(transport.post.mock.calls[0]).toEqual([
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 null,
                 expect.objectContaining({
@@ -135,7 +135,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 { RefreshRate: 120, Top: 10 },
             );
@@ -143,7 +143,7 @@ describe('openapi StreamingSubscription', () => {
 
             expect(transport.post.mock.calls.length).toEqual(1);
             expect(transport.post.mock.calls[0]).toEqual([
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource?$top=10',
                 null,
                 expect.objectContaining({
@@ -156,7 +156,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 null,
@@ -166,7 +166,7 @@ describe('openapi StreamingSubscription', () => {
 
             expect(transport.post.mock.calls.length).toEqual(1);
             expect(transport.post.mock.calls[0]).toEqual([
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 null,
                 expect.objectContaining({ headers: { Header: 'header' } }),
@@ -177,7 +177,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
             );
@@ -185,7 +185,7 @@ describe('openapi StreamingSubscription', () => {
 
             expect(transport.post.mock.calls.length).toEqual(1);
             expect(transport.post.mock.calls[0]).toEqual([
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 null,
                 expect.not.objectContaining({ headers: expect.anything() }),
@@ -197,7 +197,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 null,
@@ -225,7 +225,7 @@ describe('openapi StreamingSubscription', () => {
 
                     expect(transport.post.mock.calls.length).toEqual(2);
                     expect(transport.post.mock.calls[0]).toEqual([
-                        'serviceGroup',
+                        'servicePath',
                         'src/test/resource',
                         null,
                         expect.objectContaining({
@@ -244,7 +244,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -270,7 +270,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -295,7 +295,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -324,7 +324,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'test/resource',
                 { Format: 'application/x-protobuf' },
                 createdSpy,
@@ -358,7 +358,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -396,7 +396,7 @@ describe('openapi StreamingSubscription', () => {
             subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -494,7 +494,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -528,7 +528,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -572,7 +572,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -598,7 +598,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -618,7 +618,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -633,7 +633,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -664,7 +664,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -694,7 +694,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -734,7 +734,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -773,7 +773,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -813,7 +813,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -846,7 +846,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -879,7 +879,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -912,7 +912,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -966,7 +966,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1044,7 +1044,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1075,7 +1075,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1103,7 +1103,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1147,7 +1147,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1203,7 +1203,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1223,7 +1223,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1248,7 +1248,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1290,7 +1290,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1329,7 +1329,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1377,7 +1377,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1425,7 +1425,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1470,7 +1470,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1522,7 +1522,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 args,
                 createdSpy,
@@ -1572,7 +1572,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 args,
                 createdSpy,
@@ -1630,7 +1630,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 args,
                 createdSpy,
@@ -1661,7 +1661,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 args,
                 createdSpy,
@@ -1693,7 +1693,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 args,
                 createdSpy,
@@ -1738,7 +1738,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1780,7 +1780,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1815,7 +1815,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1869,7 +1869,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,
@@ -1905,7 +1905,7 @@ describe('openapi StreamingSubscription', () => {
             const subscription = new Subscription(
                 '123',
                 transport,
-                'serviceGroup',
+                'servicePath',
                 'src/test/resource',
                 {},
                 createdSpy,

--- a/src/openapi/transport/auth.js
+++ b/src/openapi/transport/auth.js
@@ -17,7 +17,7 @@ const DEFAULT_AUTH_ERRORS_DEBOUNCE_PERIOD = 30000; // ms
 // -- Local methods section --
 
 function makeTransportMethod(method) {
-    return function(serviceGroup, urlTemplate, templateArgs, options) {
+    return function(servicePath, urlTemplate, templateArgs, options) {
         const newOptions = {
             ...options,
             headers: {
@@ -27,7 +27,7 @@ function makeTransportMethod(method) {
         };
 
         return this.transport[method](
-            serviceGroup,
+            servicePath,
             urlTemplate,
             templateArgs,
             newOptions,

--- a/src/openapi/transport/auth.spec.js
+++ b/src/openapi/transport/auth.spec.js
@@ -49,7 +49,7 @@ describe('openapi TransportAuth', () => {
 
             expect(fetch).not.toBeCalled();
             authProvider.getExpiry.mockImplementation(() => 1);
-            transportAuth.get('service_group', 'url').catch(noop);
+            transportAuth.get('service_path', 'url').catch(noop);
             expect(fetch).toBeCalledTimes(1);
             fetch.mockClear();
 
@@ -67,7 +67,7 @@ describe('openapi TransportAuth', () => {
             transportAuth = new TransportAuth('localhost', authProvider);
 
             expect(fetch).not.toBeCalled();
-            transportAuth.get('service_group', 'url').catch(noop);
+            transportAuth.get('service_path', 'url').catch(noop);
             expect(fetch).toBeCalledTimes(1);
             fetch.mockClear();
 
@@ -85,7 +85,7 @@ describe('openapi TransportAuth', () => {
             transportAuth = new TransportAuth('localhost', authProvider);
 
             expect(fetch).not.toBeCalled();
-            transportAuth.get('service_group', 'url');
+            transportAuth.get('service_path', 'url');
             expect(fetch).toBeCalledTimes(1);
             expect(fetch).toHaveBeenCalledWith(
                 expect.anything(),
@@ -98,7 +98,7 @@ describe('openapi TransportAuth', () => {
             );
             fetch.mockClear();
 
-            transportAuth.get('service_group', 'url', {}, {});
+            transportAuth.get('service_path', 'url', {}, {});
             expect(fetch).toBeCalledTimes(1);
             expect(fetch).toHaveBeenCalledWith(
                 expect.anything(),
@@ -114,11 +114,11 @@ describe('openapi TransportAuth', () => {
         it('supports all the http verbs', function() {
             transportAuth = new TransportAuth('localhost', authProvider);
 
-            transportAuth.get('service_group', 'url');
-            transportAuth.put('service_group', 'url');
-            transportAuth.post('service_group', 'url');
-            transportAuth.patch('service_group', 'url');
-            transportAuth.delete('service_group', 'url');
+            transportAuth.get('service_path', 'url');
+            transportAuth.put('service_path', 'url');
+            transportAuth.post('service_path', 'url');
+            transportAuth.patch('service_path', 'url');
+            transportAuth.delete('service_path', 'url');
             expect(fetch).toBeCalledTimes(5);
             expect(fetch.mock.calls[0]).toEqual([
                 expect.anything(),
@@ -173,7 +173,7 @@ describe('openapi TransportAuth', () => {
 
             expect(fetch).not.toBeCalled();
             transportAuth.get(
-                'service_group',
+                'service_path',
                 'url',
                 {},
                 { headers: { Authorization: 'MYTOKEN' } },
@@ -195,11 +195,11 @@ describe('openapi TransportAuth', () => {
 
             expect(
                 transportAuth.authorizationErrors[
-                    'localhost/openapi/service_group/url'
+                    'localhost/openapi/service_path/url'
                 ],
             ).toBe(undefined);
 
-            transportAuth.post('service_group', 'url').catch(noop);
+            transportAuth.post('service_path', 'url').catch(noop);
             transportAuth.state = 1;
             fetch.resolve(401, {
                 error: 401,
@@ -209,7 +209,7 @@ describe('openapi TransportAuth', () => {
             setTimeout(() => {
                 expect(
                     transportAuth.authorizationErrors[
-                        'localhost/openapi/service_group/url'
+                        'localhost/openapi/service_path/url'
                     ],
                 ).toEqual([expect.any(Object)]);
                 done();
@@ -221,14 +221,14 @@ describe('openapi TransportAuth', () => {
 
             expect(
                 transportAuth.authorizationErrors[
-                    'localhost/openapi/service_group/url'
+                    'localhost/openapi/service_path/url'
                 ],
             ).toBe(undefined);
 
             return waterfallTimeout([
                 () => {
                     authProvider.getExpiry.mockImplementation(() => 1);
-                    transportAuth.post('service_group', 'url').catch(noop);
+                    transportAuth.post('service_path', 'url').catch(noop);
                     transportAuth.state = 1;
                     fetch.resolve(401, {
                         error: 401,
@@ -239,13 +239,13 @@ describe('openapi TransportAuth', () => {
                     expect(authProvider.tokenRejected).toHaveBeenCalledTimes(1);
                     expect(
                         transportAuth.authorizationErrors[
-                            'localhost/openapi/service_group/url'
+                            'localhost/openapi/service_path/url'
                         ],
                     ).toEqual([expect.any(Object)]);
                 },
                 () => {
                     authProvider.getExpiry.mockImplementation(() => 2);
-                    transportAuth.post('service_group', 'url').catch(noop);
+                    transportAuth.post('service_path', 'url').catch(noop);
                     transportAuth.state = 1;
                     fetch.resolve(401, {
                         error: 401,
@@ -256,7 +256,7 @@ describe('openapi TransportAuth', () => {
                     expect(authProvider.tokenRejected).toHaveBeenCalledTimes(1);
                     expect(
                         transportAuth.authorizationErrors[
-                            'localhost/openapi/service_group/url'
+                            'localhost/openapi/service_path/url'
                         ],
                     ).toEqual([expect.any(Object), expect.any(Object)]);
 
@@ -270,12 +270,12 @@ describe('openapi TransportAuth', () => {
 
             expect(
                 transportAuth.authorizationErrors[
-                    'localhost/openapi/service_group/url'
+                    'localhost/openapi/service_path/url'
                 ],
             ).toBe(undefined);
             expect(
                 transportAuth.authorizationErrors[
-                    'localhost/openapi/service_group/url-2'
+                    'localhost/openapi/service_path/url-2'
                 ],
             ).toBe(undefined);
 
@@ -283,7 +283,7 @@ describe('openapi TransportAuth', () => {
                 // Fail the first endpoint
                 () => {
                     authProvider.getExpiry.mockImplementation(() => 1);
-                    transportAuth.post('service_group', 'url').catch(noop);
+                    transportAuth.post('service_path', 'url').catch(noop);
                     transportAuth.state = 1;
                     fetch.resolve(401, {
                         error: 401,
@@ -292,7 +292,7 @@ describe('openapi TransportAuth', () => {
                 },
                 () => {
                     authProvider.getExpiry.mockImplementation(() => 2);
-                    transportAuth.post('service_group', 'url').catch(noop);
+                    transportAuth.post('service_path', 'url').catch(noop);
                     transportAuth.state = 1;
                     fetch.resolve(401, {
                         error: 401,
@@ -303,14 +303,14 @@ describe('openapi TransportAuth', () => {
                     expect(authProvider.tokenRejected).toHaveBeenCalledTimes(1);
                     expect(
                         transportAuth.authorizationErrors[
-                            'localhost/openapi/service_group/url'
+                            'localhost/openapi/service_path/url'
                         ],
                     ).toEqual([expect.any(Object), expect.any(Object)]);
                 },
                 // now have a failure with the new endpoint
                 () => {
                     authProvider.getExpiry.mockImplementation(() => 3);
-                    transportAuth.post('service_group', 'url-2').catch(noop);
+                    transportAuth.post('service_path', 'url-2').catch(noop);
                     transportAuth.state = 1;
                     fetch.resolve(401, {
                         error: 401,
@@ -321,7 +321,7 @@ describe('openapi TransportAuth', () => {
                     expect(authProvider.tokenRejected).toHaveBeenCalledTimes(2);
                     expect(
                         transportAuth.authorizationErrors[
-                            'localhost/openapi/service_group/url-2'
+                            'localhost/openapi/service_path/url-2'
                         ],
                     ).toEqual([expect.any(Object)]);
 
@@ -335,19 +335,19 @@ describe('openapi TransportAuth', () => {
 
             expect(
                 transportAuth.authorizationErrors[
-                    'localhost/openapi/service_group/url'
+                    'localhost/openapi/service_path/url'
                 ],
             ).toBe(undefined);
             expect(
                 transportAuth.authorizationErrors[
-                    'localhost/openapi/service_group/url-2'
+                    'localhost/openapi/service_path/url-2'
                 ],
             ).toBe(undefined);
 
             waterfallTimeout([
                 () => {
                     authProvider.getExpiry.mockImplementation(() => 1);
-                    transportAuth.post('service_group', 'url').catch(noop);
+                    transportAuth.post('service_path', 'url').catch(noop);
                     transportAuth.state = 1;
                     fetch.resolve(401, {
                         error: 401,
@@ -356,7 +356,7 @@ describe('openapi TransportAuth', () => {
                 },
                 () => {
                     authProvider.getExpiry.mockImplementation(() => 2);
-                    transportAuth.post('service_group', 'url').catch(noop);
+                    transportAuth.post('service_path', 'url').catch(noop);
                     transportAuth.state = 1;
                     fetch.resolve(401, {
                         error: 401,
@@ -367,7 +367,7 @@ describe('openapi TransportAuth', () => {
                     expect(authProvider.tokenRejected).toHaveBeenCalledTimes(1);
                     expect(
                         transportAuth.authorizationErrors[
-                            'localhost/openapi/service_group/url'
+                            'localhost/openapi/service_path/url'
                         ],
                     ).toEqual(expect.any(Array));
 
@@ -375,7 +375,7 @@ describe('openapi TransportAuth', () => {
 
                     expect(
                         transportAuth.authorizationErrors[
-                            'localhost/openapi/service_group/url'
+                            'localhost/openapi/service_path/url'
                         ],
                     ).toBe(undefined);
 
@@ -389,19 +389,19 @@ describe('openapi TransportAuth', () => {
 
             expect(
                 transportAuth.authorizationErrors[
-                    'localhost/openapi/service_group/url'
+                    'localhost/openapi/service_path/url'
                 ],
             ).toBe(undefined);
             expect(
                 transportAuth.authorizationErrors[
-                    'localhost/openapi/service_group/url-2'
+                    'localhost/openapi/service_path/url-2'
                 ],
             ).toBe(undefined);
 
             waterfallTimeout([
                 () => {
                     authProvider.getExpiry.mockImplementation(() => 1);
-                    transportAuth.post('service_group', 'url').catch(noop);
+                    transportAuth.post('service_path', 'url').catch(noop);
                     transportAuth.state = 1;
                     fetch.resolve(401, {
                         error: 401,
@@ -412,7 +412,7 @@ describe('openapi TransportAuth', () => {
                     tick(30001);
 
                     authProvider.getExpiry.mockImplementation(() => 2);
-                    transportAuth.post('service_group', 'url').catch(noop);
+                    transportAuth.post('service_path', 'url').catch(noop);
                     transportAuth.state = 1;
                     fetch.resolve(401, {
                         error: 401,

--- a/src/openapi/transport/auth.spec.js
+++ b/src/openapi/transport/auth.spec.js
@@ -45,10 +45,7 @@ describe('openapi TransportAuth', () => {
 
     describe('refreshing', () => {
         it('refreshes the token when a transport call returns a 401', (done) => {
-            transportAuth = new TransportAuth(
-                'localhost/openapi',
-                authProvider,
-            );
+            transportAuth = new TransportAuth('localhost', authProvider);
 
             expect(fetch).not.toBeCalled();
             authProvider.getExpiry.mockImplementation(() => 1);
@@ -67,10 +64,7 @@ describe('openapi TransportAuth', () => {
         });
 
         it('does nothing when a transport call fails with a different error code', (done) => {
-            transportAuth = new TransportAuth(
-                'localhost/openapi',
-                authProvider,
-            );
+            transportAuth = new TransportAuth('localhost', authProvider);
 
             expect(fetch).not.toBeCalled();
             transportAuth.get('service_group', 'url').catch(noop);
@@ -88,10 +82,7 @@ describe('openapi TransportAuth', () => {
 
     describe('transport', function() {
         it('adds on a auth header when methods are called', function() {
-            transportAuth = new TransportAuth(
-                'localhost/openapi',
-                authProvider,
-            );
+            transportAuth = new TransportAuth('localhost', authProvider);
 
             expect(fetch).not.toBeCalled();
             transportAuth.get('service_group', 'url');
@@ -121,10 +112,7 @@ describe('openapi TransportAuth', () => {
         });
 
         it('supports all the http verbs', function() {
-            transportAuth = new TransportAuth(
-                'localhost/openapi',
-                authProvider,
-            );
+            transportAuth = new TransportAuth('localhost', authProvider);
 
             transportAuth.get('service_group', 'url');
             transportAuth.put('service_group', 'url');
@@ -181,10 +169,7 @@ describe('openapi TransportAuth', () => {
         });
 
         it('overrides an auth header if one exists', function() {
-            transportAuth = new TransportAuth(
-                'localhost/openapi',
-                authProvider,
-            );
+            transportAuth = new TransportAuth('localhost', authProvider);
 
             expect(fetch).not.toBeCalled();
             transportAuth.get(
@@ -206,10 +191,7 @@ describe('openapi TransportAuth', () => {
         });
 
         it('counts transport authorization errors', function(done) {
-            transportAuth = new TransportAuth(
-                'localhost/openapi',
-                authProvider,
-            );
+            transportAuth = new TransportAuth('localhost', authProvider);
 
             expect(
                 transportAuth.authorizationErrors[
@@ -235,10 +217,7 @@ describe('openapi TransportAuth', () => {
         });
 
         it('blocks re-requesting authorization token if auth errors happen on different tokens', function(done) {
-            transportAuth = new TransportAuth(
-                'localhost/openapi',
-                authProvider,
-            );
+            transportAuth = new TransportAuth('localhost', authProvider);
 
             expect(
                 transportAuth.authorizationErrors[
@@ -287,10 +266,7 @@ describe('openapi TransportAuth', () => {
         });
 
         it('doesnt block re-requesting if limit not reached for separate endpoints', function(done) {
-            transportAuth = new TransportAuth(
-                'localhost/openapi',
-                authProvider,
-            );
+            transportAuth = new TransportAuth('localhost', authProvider);
 
             expect(
                 transportAuth.authorizationErrors[
@@ -355,10 +331,7 @@ describe('openapi TransportAuth', () => {
         });
 
         it('resets error counters after dispose', function(done) {
-            transportAuth = new TransportAuth(
-                'localhost/openapi',
-                authProvider,
-            );
+            transportAuth = new TransportAuth('localhost', authProvider);
 
             expect(
                 transportAuth.authorizationErrors[
@@ -412,10 +385,7 @@ describe('openapi TransportAuth', () => {
         });
 
         it('resets error counters after debounce timeout is reached', function(done) {
-            transportAuth = new TransportAuth(
-                'localhost/openapi',
-                authProvider,
-            );
+            transportAuth = new TransportAuth('localhost', authProvider);
 
             expect(
                 transportAuth.authorizationErrors[
@@ -460,10 +430,7 @@ describe('openapi TransportAuth', () => {
 
     describe('areUrlAuthErrorsProblematic', () => {
         it('should return value for specific url', () => {
-            transportAuth = new TransportAuth(
-                'localhost/openapi',
-                authProvider,
-            );
+            transportAuth = new TransportAuth('localhost', authProvider);
 
             transportAuth.authorizationErrors = {
                 'new-url': [{ authExpiry: 1 }],
@@ -482,10 +449,7 @@ describe('openapi TransportAuth', () => {
         });
 
         it('should return true for url which is not present in errors map', () => {
-            transportAuth = new TransportAuth(
-                'localhost/openapi',
-                authProvider,
-            );
+            transportAuth = new TransportAuth('localhost', authProvider);
 
             transportAuth.authorizationErrors = {
                 'new-url': [{ authExpiry: 1 }],

--- a/src/openapi/transport/batch.js
+++ b/src/openapi/transport/batch.js
@@ -181,6 +181,7 @@ function TransportBatch(transport, baseUrl, options) {
         basePath += '/';
     }
 
+    // Batching is a service group level facility, so isn't applicable/available for /oapi
     this.basePath = basePath + 'openapi/';
 
     if (options && options.host) {

--- a/src/openapi/transport/batch.js
+++ b/src/openapi/transport/batch.js
@@ -180,7 +180,7 @@ function TransportBatch(transport, baseUrl, options) {
         basePath += '/';
     }
 
-    this.basePath = basePath;
+    this.basePath = basePath + 'openapi/';
 
     if (options && options.host) {
         this.host = options.host;

--- a/src/openapi/transport/batch.js
+++ b/src/openapi/transport/batch.js
@@ -22,7 +22,7 @@ function emptyQueueIntoServiceGroups() {
     const serviceGroupMap = {};
     for (let i = 0; i < this.queue.length; i++) {
         const item = this.queue[i];
-        const serviceGroup = item.serviceGroup;
+        const serviceGroup = item.servicePath;
         let serviceGroupList = serviceGroupMap[serviceGroup];
         if (!serviceGroupList) {
             serviceGroupList = serviceGroupMap[serviceGroup] = [];
@@ -229,7 +229,7 @@ TransportBatch.prototype.addToQueue = function(item) {
  * @param item
  */
 TransportBatch.prototype.shouldQueue = function(item) {
-    const serviceOptions = this.services[item.serviceGroup] || {};
+    const serviceOptions = this.services[item.servicePath] || {};
 
     return !serviceOptions.useCloud;
 };

--- a/src/openapi/transport/batch.js
+++ b/src/openapi/transport/batch.js
@@ -157,7 +157,7 @@ function runBatchCall(serviceGroup, callList) {
  * @param {Object} [options]
  * @param {number} [options.timeoutMs=0] - Timeout after starting to que items before sending a batch request.
  * @param {string} [options.host=global.location.host] - The host to use in the batch request. If not set defaults to global.location.host.
- * @param {object} [options.services]
+ * @param {Object.<string, saxo.ServiceOptions>} [options.services] - Per-service options, keyed by service path.
  */
 function TransportBatch(transport, baseUrl, options) {
     TransportQueue.call(this, transport);

--- a/src/openapi/transport/batch.js
+++ b/src/openapi/transport/batch.js
@@ -157,6 +157,7 @@ function runBatchCall(serviceGroup, callList) {
  * @param {Object} [options]
  * @param {number} [options.timeoutMs=0] - Timeout after starting to que items before sending a batch request.
  * @param {string} [options.host=global.location.host] - The host to use in the batch request. If not set defaults to global.location.host.
+ * @param {object} [options.services]
  */
 function TransportBatch(transport, baseUrl, options) {
     TransportQueue.call(this, transport);
@@ -189,6 +190,7 @@ function TransportBatch(transport, baseUrl, options) {
     }
 
     this.timeoutMs = (options && options.timeoutMs) || 0;
+    this.services = (options && options.services) || {};
     this.isQueueing = true;
 }
 TransportBatch.prototype = Object.create(TransportQueue.prototype, {
@@ -220,6 +222,16 @@ TransportBatch.prototype.addToQueue = function(item) {
             );
         }
     }
+};
+
+/**
+ * @private
+ * @param item
+ */
+TransportBatch.prototype.shouldQueue = function(item) {
+    const serviceOptions = this.services[item.serviceGroup] || {};
+
+    return !serviceOptions.useCloud;
 };
 
 /**

--- a/src/openapi/transport/batch.spec.js
+++ b/src/openapi/transport/batch.spec.js
@@ -110,6 +110,33 @@ describe('openapi TransportBatch', () => {
         expect(transport.post.mock.calls.length).toEqual(0);
     });
 
+    it('does not batch calls to services configured to use cloud', function() {
+        transportBatch = new TransportBatch(transport, validBaseUrl, {
+            services: {
+                'usersettings/v2': { useCloud: true },
+            },
+        });
+
+        transportBatch.get('usersettings/v2', 'common');
+
+        expect(transport.get.mock.calls.length).toEqual(1);
+    });
+
+    it('batches calls to services configured to use on-prem', function() {
+        transportBatch = new TransportBatch(transport, validBaseUrl, {
+            timeoutMs: 0,
+            services: {
+                'usersettings/v2': { useCloud: false },
+            },
+        });
+
+        transportBatch.get('usersettings/v2', 'common');
+        expect(transport.get.mock.calls.length).toEqual(0);
+
+        tick(1);
+        expect(transport.get.mock.calls.length).toEqual(1);
+    });
+
     it('queues up calls immediately if timeout is 0', function() {
         transportBatch = new TransportBatch(transport, validBaseUrl, {
             timeoutMs: 0,

--- a/src/openapi/transport/batch.spec.js
+++ b/src/openapi/transport/batch.spec.js
@@ -18,7 +18,7 @@ jest.mock('../../utils/function', () => {
 });
 
 describe('openapi TransportBatch', () => {
-    const validBaseUrl = 'localhost/openapi/';
+    const validBaseUrl = 'localhost/';
     let transport;
     let transportBatch;
 
@@ -67,19 +67,16 @@ describe('openapi TransportBatch', () => {
         }).toThrow();
 
         transportBatch = new TransportBatch(transport, 'localhost');
-        expect(transportBatch.basePath).toEqual('/');
-
-        transportBatch = new TransportBatch(transport, 'localhost/openapi');
         expect(transportBatch.basePath).toEqual('/openapi/');
 
-        transportBatch = new TransportBatch(transport, 'localhost/openapi/');
-        expect(transportBatch.basePath).toEqual('/openapi/');
+        transportBatch = new TransportBatch(transport, 'localhost/foo');
+        expect(transportBatch.basePath).toEqual('/foo/openapi/');
 
-        transportBatch = new TransportBatch(
-            transport,
-            'http://localhost/openapi/',
-        );
-        expect(transportBatch.basePath).toEqual('/openapi/');
+        transportBatch = new TransportBatch(transport, 'localhost/foo/');
+        expect(transportBatch.basePath).toEqual('/foo/openapi/');
+
+        transportBatch = new TransportBatch(transport, 'http://localhost/foo/');
+        expect(transportBatch.basePath).toEqual('/foo/openapi/');
     });
 
     it('defaults to timeout 0', function() {

--- a/src/openapi/transport/core.js
+++ b/src/openapi/transport/core.js
@@ -55,9 +55,12 @@ function generateTransportCall(method) {
                 (options && options.requestId) || getRequestId();
         }
 
+        const serviceOptions = this.services[serviceGroup] || {};
+        const basePath = serviceOptions.useCloud ? '/oapi' : '/openapi';
+
         return this.fetch(
             method,
-            this.baseUrl + '/openapi/' + serviceGroup + '/' + url,
+            this.baseUrl + basePath + '/' + serviceGroup + '/' + url,
             {
                 body,
                 headers,
@@ -79,6 +82,7 @@ function generateTransportCall(method) {
  * @param {object} [options]
  * @param {string} [options.language] - The language sent as a header if not overridden.
  * @param {boolean} [options.defaultCache=true] - Sets the default caching behaviour if not overridden on a call.
+ * @param {object} [options.services]
  */
 function Transport(baseUrl, options) {
     if (!baseUrl) {
@@ -90,6 +94,7 @@ function Transport(baseUrl, options) {
         options && typeof options.defaultCache === 'boolean'
             ? options.defaultCache
             : DEFAULT_CACHE;
+    this.services = (options && options.services) || {};
 }
 
 /**

--- a/src/openapi/transport/core.js
+++ b/src/openapi/transport/core.js
@@ -18,16 +18,14 @@ const DEFAULT_CACHE = true;
  * @param method
  */
 function generateTransportCall(method) {
-    return function(serviceGroup, urlTemplate, templateArgs, options) {
+    return function(servicePath, urlTemplate, templateArgs, options) {
         let body;
         let headers = {};
         let cache = this.defaultCache;
         let queryParams;
 
-        if (!serviceGroup || !urlTemplate) {
-            throw new Error(
-                'Transport calls require a service group and a URL',
-            );
+        if (!servicePath || !urlTemplate) {
+            throw new Error('Transport calls require a service path and a URL');
         }
 
         if (options) {
@@ -55,12 +53,12 @@ function generateTransportCall(method) {
                 (options && options.requestId) || getRequestId();
         }
 
-        const serviceOptions = this.services[serviceGroup] || {};
+        const serviceOptions = this.services[servicePath] || {};
         const basePath = serviceOptions.useCloud ? '/oapi' : '/openapi';
 
         return this.fetch(
             method,
-            this.baseUrl + basePath + '/' + serviceGroup + '/' + url,
+            this.baseUrl + basePath + '/' + servicePath + '/' + url,
             {
                 body,
                 headers,
@@ -107,8 +105,8 @@ function Transport(baseUrl, options) {
 /**
  * Does a get request against open api.
  * @function
- * @param {string} serviceGroup - The servicegroup to make the call on
- * @param {string} urlTemplate - The url path template which follows on from the serviceGroup to describe the path for the request.
+ * @param {string} servicePath - The service path to make the call on
+ * @param {string} urlTemplate - The url path template which follows on from the service path to describe the path for the request.
  * @param {Object} templateArgs - An object containing fields matched to the template or null if there are no templateArgs.
  * @param {Object} [options]
  * @param {Object.<string:string>} [options.headers] - A object map of headers, header key to header value
@@ -159,8 +157,8 @@ Transport.prototype.get = generateTransportCall('GET');
 /**
  * Does a put request against open api.
  * @function
- * @param {string} serviceGroup - The servicegroup to make the call on
- * @param {string} urlTemplate - The url path template which follows on from the serviceGroup to describe the path for the request.
+ * @param {string} servicePath - The service path to make the call on
+ * @param {string} urlTemplate - The url path template which follows on from the service path to describe the path for the request.
  * @param {Object} templateArgs - An object containing fields matched to the template or null if there are no templateArgs.
  * @param {Object} [options]
  * @param {Object.<string:string>} [options.headers] - A object map of headers, header key to header value
@@ -213,8 +211,8 @@ Transport.prototype.put = generateTransportCall('PUT');
 /**
  * Does a delete request against open api.
  * @function
- * @param {string} serviceGroup - The servicegroup to make the call on
- * @param {string} urlTemplate - The url path template which follows on from the serviceGroup to describe the path for the request.
+ * @param {string} servicePath - The service path to make the call on
+ * @param {string} urlTemplate - The url path template which follows on from the service path to describe the path for the request.
  * @param {Object} templateArgs - An object containing fields matched to the template or null if there are no templateArgs.
  * @param {Object} [options]
  * @param {Object.<string:string>} [options.headers] - A object map of headers, header key to header value
@@ -265,8 +263,8 @@ Transport.prototype.delete = generateTransportCall('DELETE');
 /**
  * Does a post request against open api.
  * @function
- * @param {string} serviceGroup - The servicegroup to make the call on
- * @param {string} urlTemplate - The url path template which follows on from the serviceGroup to describe the path for the request.
+ * @param {string} servicePath - The service path to make the call on
+ * @param {string} urlTemplate - The url path template which follows on from the service path to describe the path for the request.
  * @param {Object} templateArgs - An object containing fields matched to the template or null if there are no templateArgs.
  * @param {Object} [options]
  * @param {Object.<string:string>} [options.headers] - A object map of headers, header key to header value
@@ -319,8 +317,8 @@ Transport.prototype.post = generateTransportCall('POST');
 /**
  * Does a patch request against open api.
  * @function
- * @param {string} serviceGroup - The servicegroup to make the call on
- * @param {string} urlTemplate - The url path template which follows on from the serviceGroup to describe the path for the request.
+ * @param {string} servicePath - The service path to make the call on
+ * @param {string} urlTemplate - The url path template which follows on from the service path to describe the path for the request.
  * @param {Object} templateArgs - An object containing fields matched to the template or null if there are no templateArgs.
  * @param {Object} [options]
  * @param {Object.<string:string>} [options.headers] - A object map of headers, header key to header value
@@ -373,8 +371,8 @@ Transport.prototype.patch = generateTransportCall('PATCH');
 /**
  * Does a head request against open api.
  * @function
- * @param {string} serviceGroup - The servicegroup to make the call on
- * @param {string} urlTemplate - The url path template which follows on from the serviceGroup to describe the path for the request.
+ * @param {string} servicePath - The service path to make the call on
+ * @param {string} urlTemplate - The url path template which follows on from the service path to describe the path for the request.
  * @param {Object} templateArgs - An object containing fields matched to the template or null if there are no templateArgs.
  * @param {Object} [options]
  * @param {Object.<string:string>} [options.headers] - A object map of headers, header key to header value
@@ -426,8 +424,8 @@ Transport.prototype.head = generateTransportCall('HEAD');
 /**
  * Does an options request against open api.
  * @function
- * @param {string} serviceGroup - The servicegroup to make the call on
- * @param {string} urlTemplate - The url path template which follows on from the serviceGroup to describe the path for the request.
+ * @param {string} servicePath - The service path to make the call on
+ * @param {string} urlTemplate - The url path template which follows on from the service path to describe the path for the request.
  * @param {Object} templateArgs - An object containing fields matched to the template or null if there are no templateArgs.
  * @param {Object} [options]
  * @param {Object.<string:string>} [options.headers] - A object map of headers, header key to header value

--- a/src/openapi/transport/core.js
+++ b/src/openapi/transport/core.js
@@ -57,7 +57,7 @@ function generateTransportCall(method) {
 
         return this.fetch(
             method,
-            this.baseUrl + '/' + serviceGroup + '/' + url,
+            this.baseUrl + '/openapi/' + serviceGroup + '/' + url,
             {
                 body,
                 headers,

--- a/src/openapi/transport/core.js
+++ b/src/openapi/transport/core.js
@@ -74,6 +74,13 @@ function generateTransportCall(method) {
 // -- Exported methods section --
 
 /**
+ * Options pertaining to a specific service path.
+ *
+ * @typedef {Object} saxo.ServiceOptions
+ * @property {boolean} [useCloud] - Request from OpenAPI cloud (/oapi)
+ */
+
+/**
  * Handles core transport to the openapi rest service. This is little more than a thin layer on top of fetch, adding
  * cache breaking, language header adding and a convenient mechanism for making transport calls.
  * @class
@@ -82,7 +89,7 @@ function generateTransportCall(method) {
  * @param {object} [options]
  * @param {string} [options.language] - The language sent as a header if not overridden.
  * @param {boolean} [options.defaultCache=true] - Sets the default caching behaviour if not overridden on a call.
- * @param {object} [options.services]
+ * @param {Object.<string, saxo.ServiceOptions>} [options.services] - Per-service options, keyed by service path.
  */
 function Transport(baseUrl, options) {
     if (!baseUrl) {

--- a/src/openapi/transport/core.spec.js
+++ b/src/openapi/transport/core.spec.js
@@ -29,6 +29,77 @@ describe('openapi TransportCore', () => {
         });
     });
 
+    describe('base selection for on-prem or cloud', () => {
+        it('assumes on-prem when given no configuration', () => {
+            transport = new TransportCore('localhost');
+
+            transport.get('service_path', 'endpoint');
+
+            expect(fetch).toHaveBeenCalledWith(
+                'localhost/openapi/service_path/endpoint',
+                expect.anything(),
+            );
+        });
+
+        it('assumes on-prem for a service path with no configuration', () => {
+            transport = new TransportCore('localhost', {
+                services: {},
+            });
+
+            transport.get('service_path', 'endpoint');
+
+            expect(fetch).toHaveBeenCalledWith(
+                'localhost/openapi/service_path/endpoint',
+                expect.anything(),
+            );
+        });
+
+        it('assumes on-prem for a service path with no relevant configuration', () => {
+            transport = new TransportCore('localhost', {
+                services: {
+                    service_path: {},
+                },
+            });
+
+            transport.get('service_path', 'endpoint');
+
+            expect(fetch).toHaveBeenCalledWith(
+                'localhost/openapi/service_path/endpoint',
+                expect.anything(),
+            );
+        });
+
+        it('uses on-prem for a service path configured as such', () => {
+            transport = new TransportCore('localhost', {
+                services: {
+                    service_path: { useCloud: false },
+                },
+            });
+
+            transport.get('service_path', 'endpoint');
+
+            expect(fetch).toHaveBeenCalledWith(
+                'localhost/openapi/service_path/endpoint',
+                expect.anything(),
+            );
+        });
+
+        it('uses cloud for a service path configured as such', () => {
+            transport = new TransportCore('localhost', {
+                services: {
+                    service_path: { useCloud: true },
+                },
+            });
+
+            transport.get('service_path', 'endpoint');
+
+            expect(fetch).toHaveBeenCalledWith(
+                'localhost/oapi/service_path/endpoint',
+                expect.anything(),
+            );
+        });
+    });
+
     describe('url templating', () => {
         it('basically works', () => {
             transport = new TransportCore('localhost');

--- a/src/openapi/transport/core.spec.js
+++ b/src/openapi/transport/core.spec.js
@@ -16,11 +16,11 @@ describe('openapi TransportCore', () => {
     });
 
     describe('parameters', () => {
-        it('requires a service group and url', () => {
+        it('requires a service path and url', () => {
             transport = new TransportCore('localhost');
             expect(() => transport.get()).toThrow();
             expect(() => transport.get('', '')).toThrow();
-            expect(() => transport.get('service_group', '')).toThrow();
+            expect(() => transport.get('service_path', '')).toThrow();
             expect(() => transport.get('', 'url')).toThrow();
 
             expect(() => new TransportCore()).toThrow();
@@ -32,26 +32,26 @@ describe('openapi TransportCore', () => {
     describe('url templating', () => {
         it('basically works', () => {
             transport = new TransportCore('localhost');
-            transport.get('service_group', 'account/info/{user}/{account}', {
+            transport.get('service_path', 'account/info/{user}/{account}', {
                 user: 'te',
                 account: 'st',
             });
 
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
-                'localhost/openapi/service_group/account/info/te/st',
+                'localhost/openapi/service_path/account/info/te/st',
                 expect.anything(),
             ]);
             fetch.mockClear();
 
             transport.get(
-                'service_group',
+                'service_path',
                 'account/info/{user}?acc={account}&thingy={thing}',
                 { user: 'te', account: 'st', thing: 'ing' },
             );
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
-                'localhost/openapi/service_group/account/info/te?acc=st&thingy=ing',
+                'localhost/openapi/service_path/account/info/te?acc=st&thingy=ing',
                 expect.anything(),
             ]);
             fetch.mockClear();
@@ -59,13 +59,13 @@ describe('openapi TransportCore', () => {
 
         it('includes multiple query params', () => {
             transport = new TransportCore('localhost');
-            transport.get('service_group', 'account/info', null, {
+            transport.get('service_path', 'account/info', null, {
                 queryParams: { a: 1, b: 2 },
             });
 
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
-                'localhost/openapi/service_group/account/info?a=1&b=2',
+                'localhost/openapi/service_path/account/info?a=1&b=2',
                 expect.anything(),
             ]);
             fetch.mockClear();
@@ -73,13 +73,13 @@ describe('openapi TransportCore', () => {
 
         it('allows query params option and query params in the template', () => {
             transport = new TransportCore('localhost');
-            transport.get('service_group', 'account/info?a=1&b=2', null, {
+            transport.get('service_path', 'account/info?a=1&b=2', null, {
                 queryParams: { c: 3, d: 4 },
             });
 
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
-                'localhost/openapi/service_group/account/info?a=1&b=2&c=3&d=4',
+                'localhost/openapi/service_path/account/info?a=1&b=2&c=3&d=4',
                 expect.anything(),
             ]);
             fetch.mockClear();
@@ -87,14 +87,14 @@ describe('openapi TransportCore', () => {
 
         it('url encodes template args', () => {
             transport = new TransportCore('localhost');
-            transport.get('service_group', 'account/info/{user}/{account}', {
+            transport.get('service_path', 'account/info/{user}/{account}', {
                 user: 'te ?=!/\\',
                 account: String.fromCharCode(160),
             });
 
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
-                'localhost/openapi/service_group/account/info/te%20%3F%3D!%2F%5C/%C2%A0',
+                'localhost/openapi/service_path/account/info/te%20%3F%3D!%2F%5C/%C2%A0',
                 expect.anything(),
             ]);
             fetch.mockClear();
@@ -102,13 +102,13 @@ describe('openapi TransportCore', () => {
 
         it('url encodes queryParams', () => {
             transport = new TransportCore('localhost');
-            transport.get('service_group', 'account/info', null, {
+            transport.get('service_path', 'account/info', null, {
                 queryParams: { a: '&=' },
             });
 
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
-                'localhost/openapi/service_group/account/info?a=%26%3D',
+                'localhost/openapi/service_path/account/info?a=%26%3D',
                 expect.anything(),
             ]);
             fetch.mockClear();
@@ -119,7 +119,7 @@ describe('openapi TransportCore', () => {
         it('rejects a 400 response', (done) => {
             transport = new TransportCore('localhost');
             const getPromise = transport.get(
-                'service_group',
+                'service_path',
                 'account/info',
                 null,
             );
@@ -137,7 +137,7 @@ describe('openapi TransportCore', () => {
         it('resolves a 200 response', (done) => {
             transport = new TransportCore('localhost');
             const getPromise = transport.get(
-                'service_group',
+                'service_path',
                 'account/info',
                 null,
             );
@@ -155,7 +155,7 @@ describe('openapi TransportCore', () => {
         it('resolves a 304 response', (done) => {
             transport = new TransportCore('localhost');
             const getPromise = transport.get(
-                'service_group',
+                'service_path',
                 'account/info',
                 null,
             );
@@ -178,14 +178,14 @@ describe('openapi TransportCore', () => {
             // Currently EDGE browser will fail if GET requests have for example null body in the request.
 
             transport = new TransportCore('localhost');
-            transport.get('service_group', 'account/info/{user}/{account}', {
+            transport.get('service_path', 'account/info/{user}/{account}', {
                 user: 'te',
                 account: 'st',
             });
 
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
-                'localhost/openapi/service_group/account/info/te/st',
+                'localhost/openapi/service_path/account/info/te/st',
                 {
                     body: undefined,
                     method: 'GET',
@@ -200,7 +200,7 @@ describe('openapi TransportCore', () => {
         it('allows an object', () => {
             transport = new TransportCore('localhost');
             transport.post(
-                'service_group',
+                'service_path',
                 'account/info/{user}/{account}',
                 { user: 'te', account: 'st' },
                 { body: { Test: true } },
@@ -208,7 +208,7 @@ describe('openapi TransportCore', () => {
 
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
-                'localhost/openapi/service_group/account/info/te/st',
+                'localhost/openapi/service_path/account/info/te/st',
                 {
                     body: '{"Test":true}',
                     method: 'POST',
@@ -226,7 +226,7 @@ describe('openapi TransportCore', () => {
         it('allows a string', () => {
             transport = new TransportCore('localhost');
             transport.post(
-                'service_group',
+                'service_path',
                 'account/info/{user}/{account}',
                 { user: 'te', account: 'st' },
                 { body: '{"Test":true}' },
@@ -234,7 +234,7 @@ describe('openapi TransportCore', () => {
 
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
-                'localhost/openapi/service_group/account/info/te/st',
+                'localhost/openapi/service_path/account/info/te/st',
                 {
                     body: '{"Test":true}',
                     method: 'POST',
@@ -328,7 +328,7 @@ describe('openapi TransportCore', () => {
         it('gets text from a multipart/mixed', (done) => {
             transport = new TransportCore('localhost');
             const getPromise = transport.get(
-                'service_group',
+                'service_path',
                 'account/info',
                 null,
             );
@@ -352,7 +352,7 @@ describe('openapi TransportCore', () => {
         it('parses a json response', (done) => {
             transport = new TransportCore('localhost');
             const getPromise = transport.get(
-                'service_group',
+                'service_path',
                 'account/info',
                 null,
             );
@@ -382,7 +382,7 @@ describe('openapi TransportCore', () => {
         it('parses a json response when a call fails', (done) => {
             transport = new TransportCore('localhost');
             const getPromise = transport.get(
-                'service_group',
+                'service_path',
                 'account/info',
                 null,
             );
@@ -412,7 +412,7 @@ describe('openapi TransportCore', () => {
         it('copes with an exception reject', (done) => {
             transport = new TransportCore('localhost');
             const getPromise = transport.get(
-                'service_group',
+                'service_path',
                 'account/info',
                 null,
             );
@@ -431,7 +431,7 @@ describe('openapi TransportCore', () => {
         it('parses a json response when a call is resolved, but failed due to response status', (done) => {
             transport = new TransportCore('localhost');
             const getPromise = transport.get(
-                'service_group',
+                'service_path',
                 'account/info',
                 null,
             );
@@ -461,7 +461,7 @@ describe('openapi TransportCore', () => {
         it('copes with invalid json', (done) => {
             transport = new TransportCore('localhost');
             const getPromise = transport.get(
-                'service_group',
+                'service_path',
                 'account/info',
                 null,
             );
@@ -508,15 +508,15 @@ describe('openapi TransportCore', () => {
             transport = new TransportCore('localhost');
             expect(transport.defaultCache).toEqual(true);
 
-            transport.get('service_group', 'url', null, {});
+            transport.get('service_path', 'url', null, {});
             expectItWasAllowingCaching();
             fetch.mockClear();
 
-            transport.get('service_group', 'url', null, { cache: false });
+            transport.get('service_path', 'url', null, { cache: false });
             expectItWasNotAllowingCaching();
             fetch.mockClear();
 
-            transport.get('service_group', 'url', null, { cache: true });
+            transport.get('service_path', 'url', null, { cache: true });
             expectItWasAllowingCaching();
             fetch.mockClear();
 
@@ -525,16 +525,16 @@ describe('openapi TransportCore', () => {
             });
             expect(transport.defaultCache).toEqual(false);
 
-            transport.get('service_group', 'url', null, {});
+            transport.get('service_path', 'url', null, {});
             expectItWasNotAllowingCaching();
             fetch.mockClear();
 
-            transport.get('service_group', 'url', null, { cache: false });
+            transport.get('service_path', 'url', null, { cache: false });
             expectItWasNotAllowingCaching();
             fetch.mockClear();
 
             // test state has not changed
-            transport.get('service_group', 'url', null, { cache: true });
+            transport.get('service_path', 'url', null, { cache: true });
             expectItWasAllowingCaching();
             fetch.mockClear();
 
@@ -543,16 +543,16 @@ describe('openapi TransportCore', () => {
             });
             expect(transport.defaultCache).toEqual(true);
 
-            transport.get('service_group', 'url', null, {});
+            transport.get('service_path', 'url', null, {});
             expectItWasAllowingCaching();
             fetch.mockClear();
 
-            transport.get('service_group', 'url', null, { cache: false });
+            transport.get('service_path', 'url', null, { cache: false });
             expectItWasNotAllowingCaching();
             fetch.mockClear();
 
             // test state has not changed
-            transport.get('service_group', 'url', null, { cache: true });
+            transport.get('service_path', 'url', null, { cache: true });
             expectItWasAllowingCaching();
             fetch.mockClear();
         });
@@ -561,7 +561,7 @@ describe('openapi TransportCore', () => {
             transport = new TransportCore('localhost');
             expect(transport.defaultCache).toEqual(true);
 
-            transport.get('service_group', 'url?param=true', null, {
+            transport.get('service_path', 'url?param=true', null, {
                 cache: false,
             });
             expect(fetch.mock.calls.length).toEqual(1);
@@ -594,30 +594,30 @@ describe('openapi TransportCore', () => {
         }
 
         it('adds on the language', () => {
-            transport.get('service_group', 'url', null, {});
+            transport.get('service_path', 'url', null, {});
             expectTheLanguageToBeSetTo('dk, *;q=0.5');
             fetch.mockClear();
 
-            transport.put('service_group', 'url', null, null);
+            transport.put('service_path', 'url', null, null);
             expectTheLanguageToBeSetTo('dk, *;q=0.5');
             fetch.mockClear();
 
-            transport.post('service_group', 'url', null, { headers: null });
+            transport.post('service_path', 'url', null, { headers: null });
             expectTheLanguageToBeSetTo('dk, *;q=0.5');
             fetch.mockClear();
 
-            transport.delete('service_group', 'url', null, { headers: {} });
+            transport.delete('service_path', 'url', null, { headers: {} });
             expectTheLanguageToBeSetTo('dk, *;q=0.5');
             fetch.mockClear();
 
-            transport.patch('service_group', 'url');
+            transport.patch('service_path', 'url');
             expectTheLanguageToBeSetTo('dk, *;q=0.5');
             fetch.mockClear();
         });
 
         it('does not override a custom language', () => {
             transport.get(
-                'service_group',
+                'service_path',
                 'url',
                 {},
                 { headers: { 'Accept-Language': 'en' } },
@@ -626,7 +626,7 @@ describe('openapi TransportCore', () => {
             fetch.mockClear();
 
             transport.put(
-                'service_group',
+                'service_path',
                 'url',
                 {},
                 { headers: { 'Accept-Language': 'dk' } },
@@ -635,7 +635,7 @@ describe('openapi TransportCore', () => {
             fetch.mockClear();
 
             transport.post(
-                'service_group',
+                'service_path',
                 'url',
                 {},
                 { headers: { 'Accept-Language': 'sv' } },
@@ -644,7 +644,7 @@ describe('openapi TransportCore', () => {
             fetch.mockClear();
 
             transport.delete(
-                'service_group',
+                'service_path',
                 'url',
                 {},
                 { headers: { 'Accept-Language': 'en' } },
@@ -653,7 +653,7 @@ describe('openapi TransportCore', () => {
             fetch.mockClear();
 
             transport.patch(
-                'service_group',
+                'service_path',
                 'url',
                 {},
                 { headers: { otherHeader: 'yes', 'Accept-Language': 'en' } },
@@ -672,7 +672,7 @@ describe('openapi TransportCore', () => {
         afterEach(() => transport.dispose());
 
         it('works', () => {
-            transport.get('service_group', 'url', null, {});
+            transport.get('service_path', 'url', null, {});
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
                 expect.anything(),
@@ -683,7 +683,7 @@ describe('openapi TransportCore', () => {
             ]);
             fetch.mockClear();
 
-            transport.put('service_group', 'url', null, null);
+            transport.put('service_path', 'url', null, null);
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
                 expect.anything(),
@@ -697,7 +697,7 @@ describe('openapi TransportCore', () => {
             ]);
             fetch.mockClear();
 
-            transport.post('service_group', 'url', null, { headers: null });
+            transport.post('service_path', 'url', null, { headers: null });
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
                 expect.anything(),
@@ -708,7 +708,7 @@ describe('openapi TransportCore', () => {
             ]);
             fetch.mockClear();
 
-            transport.delete('service_group', 'url', null, { headers: {} });
+            transport.delete('service_path', 'url', null, { headers: {} });
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
                 expect.anything(),
@@ -722,7 +722,7 @@ describe('openapi TransportCore', () => {
             ]);
             fetch.mockClear();
 
-            transport.patch('service_group', 'url');
+            transport.patch('service_path', 'url');
             expect(fetch.mock.calls.length).toEqual(1);
             expect(fetch.mock.calls[0]).toEqual([
                 expect.anything(),
@@ -748,7 +748,7 @@ describe('openapi TransportCore', () => {
         afterEach(() => transport.dispose());
 
         it('works', () => {
-            transport.patch('service_group', 'url', null, {
+            transport.patch('service_path', 'url', null, {
                 body: { exampleField: 'test' },
             });
             expect(fetch.mock.calls.length).toEqual(1);

--- a/src/openapi/transport/core.spec.js
+++ b/src/openapi/transport/core.spec.js
@@ -17,7 +17,7 @@ describe('openapi TransportCore', () => {
 
     describe('parameters', () => {
         it('requires a service group and url', () => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             expect(() => transport.get()).toThrow();
             expect(() => transport.get('', '')).toThrow();
             expect(() => transport.get('service_group', '')).toThrow();
@@ -31,7 +31,7 @@ describe('openapi TransportCore', () => {
 
     describe('url templating', () => {
         it('basically works', () => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             transport.get('service_group', 'account/info/{user}/{account}', {
                 user: 'te',
                 account: 'st',
@@ -58,7 +58,7 @@ describe('openapi TransportCore', () => {
         });
 
         it('includes multiple query params', () => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             transport.get('service_group', 'account/info', null, {
                 queryParams: { a: 1, b: 2 },
             });
@@ -72,7 +72,7 @@ describe('openapi TransportCore', () => {
         });
 
         it('allows query params option and query params in the template', () => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             transport.get('service_group', 'account/info?a=1&b=2', null, {
                 queryParams: { c: 3, d: 4 },
             });
@@ -86,7 +86,7 @@ describe('openapi TransportCore', () => {
         });
 
         it('url encodes template args', () => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             transport.get('service_group', 'account/info/{user}/{account}', {
                 user: 'te ?=!/\\',
                 account: String.fromCharCode(160),
@@ -101,7 +101,7 @@ describe('openapi TransportCore', () => {
         });
 
         it('url encodes queryParams', () => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             transport.get('service_group', 'account/info', null, {
                 queryParams: { a: '&=' },
             });
@@ -117,7 +117,7 @@ describe('openapi TransportCore', () => {
 
     describe('response code', () => {
         it('rejects a 400 response', (done) => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             const getPromise = transport.get(
                 'service_group',
                 'account/info',
@@ -135,7 +135,7 @@ describe('openapi TransportCore', () => {
             });
         });
         it('resolves a 200 response', (done) => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             const getPromise = transport.get(
                 'service_group',
                 'account/info',
@@ -153,7 +153,7 @@ describe('openapi TransportCore', () => {
             });
         });
         it('resolves a 304 response', (done) => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             const getPromise = transport.get(
                 'service_group',
                 'account/info',
@@ -177,7 +177,7 @@ describe('openapi TransportCore', () => {
             // This is quite important test which ensures that we set undefined for body when it's missing for GET requests.
             // Currently EDGE browser will fail if GET requests have for example null body in the request.
 
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             transport.get('service_group', 'account/info/{user}/{account}', {
                 user: 'te',
                 account: 'st',
@@ -198,7 +198,7 @@ describe('openapi TransportCore', () => {
         });
 
         it('allows an object', () => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             transport.post(
                 'service_group',
                 'account/info/{user}/{account}',
@@ -224,7 +224,7 @@ describe('openapi TransportCore', () => {
         });
 
         it('allows a string', () => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             transport.post(
                 'service_group',
                 'account/info/{user}/{account}',
@@ -250,7 +250,7 @@ describe('openapi TransportCore', () => {
             });
             const formData = new window.FormData();
             formData.append('hest', file);
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             transport.post(
                 'platform',
                 'v1/media/{contentLibraryId}',
@@ -276,7 +276,7 @@ describe('openapi TransportCore', () => {
             const file = new window.File(['foo'], 'foo.txt', {
                 type: 'text/plain',
             });
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             transport.post(
                 'platform',
                 'v1/media/{contentLibraryId}',
@@ -301,7 +301,7 @@ describe('openapi TransportCore', () => {
         it('allows a URLSearchParams object', () => {
             const paramsString = 'q=URLUtils.searchParams&topic=api';
             const searchParams = new window.URLSearchParams(paramsString);
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             transport.post(
                 'platform',
                 'v1/media/{contentLibraryId}',
@@ -326,7 +326,7 @@ describe('openapi TransportCore', () => {
 
     describe('response data', () => {
         it('gets text from a multipart/mixed', (done) => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             const getPromise = transport.get(
                 'service_group',
                 'account/info',
@@ -350,7 +350,7 @@ describe('openapi TransportCore', () => {
         });
 
         it('parses a json response', (done) => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             const getPromise = transport.get(
                 'service_group',
                 'account/info',
@@ -380,7 +380,7 @@ describe('openapi TransportCore', () => {
         });
 
         it('parses a json response when a call fails', (done) => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             const getPromise = transport.get(
                 'service_group',
                 'account/info',
@@ -410,7 +410,7 @@ describe('openapi TransportCore', () => {
         });
 
         it('copes with an exception reject', (done) => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             const getPromise = transport.get(
                 'service_group',
                 'account/info',
@@ -429,7 +429,7 @@ describe('openapi TransportCore', () => {
         });
 
         it('parses a json response when a call is resolved, but failed due to response status', (done) => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             const getPromise = transport.get(
                 'service_group',
                 'account/info',
@@ -459,7 +459,7 @@ describe('openapi TransportCore', () => {
         });
 
         it('copes with invalid json', (done) => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             const getPromise = transport.get(
                 'service_group',
                 'account/info',
@@ -505,7 +505,7 @@ describe('openapi TransportCore', () => {
             ]);
         }
         it('defaults to true and can be overridden globally and at each call', () => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             expect(transport.defaultCache).toEqual(true);
 
             transport.get('service_group', 'url', null, {});
@@ -520,7 +520,7 @@ describe('openapi TransportCore', () => {
             expectItWasAllowingCaching();
             fetch.mockClear();
 
-            transport = new TransportCore('localhost/openapi', {
+            transport = new TransportCore('localhost', {
                 defaultCache: false,
             });
             expect(transport.defaultCache).toEqual(false);
@@ -538,7 +538,7 @@ describe('openapi TransportCore', () => {
             expectItWasAllowingCaching();
             fetch.mockClear();
 
-            transport = new TransportCore('localhost/openapi', {
+            transport = new TransportCore('localhost', {
                 defaultCache: true,
             });
             expect(transport.defaultCache).toEqual(true);
@@ -558,7 +558,7 @@ describe('openapi TransportCore', () => {
         });
 
         it('copes with a url that already has a param', () => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             expect(transport.defaultCache).toEqual(true);
 
             transport.get('service_group', 'url?param=true', null, {
@@ -574,7 +574,7 @@ describe('openapi TransportCore', () => {
 
     describe('language', () => {
         beforeEach(() => {
-            transport = new TransportCore('localhost/openapi', {
+            transport = new TransportCore('localhost', {
                 language: 'dk',
             });
         });
@@ -665,7 +665,7 @@ describe('openapi TransportCore', () => {
 
     describe('setUseXHttpMethodOverride', () => {
         beforeEach(() => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
             transport.setUseXHttpMethodOverride(true);
         });
 
@@ -742,7 +742,7 @@ describe('openapi TransportCore', () => {
 
     describe('PATCH body defaulting', () => {
         beforeEach(() => {
-            transport = new TransportCore('localhost/openapi');
+            transport = new TransportCore('localhost');
         });
 
         afterEach(() => transport.dispose());

--- a/src/openapi/transport/queue.js
+++ b/src/openapi/transport/queue.js
@@ -35,7 +35,7 @@ function transportMethod(method) {
                 reject,
             };
 
-            if (this.isQueueing) {
+            if (this.isQueueing && this.shouldQueue(queueItem)) {
                 this.addToQueue(queueItem);
             } else {
                 this.runQueueItem(queueItem);
@@ -207,6 +207,14 @@ TransportQueue.prototype.runQueueItem = function(item) {
  */
 TransportQueue.prototype.addToQueue = function(item) {
     this.queue.push(item);
+};
+
+/**
+ * @protected
+ * @param item
+ */
+TransportQueue.prototype.shouldQueue = function(item) {
+    return true;
 };
 
 /**

--- a/src/openapi/transport/queue.js
+++ b/src/openapi/transport/queue.js
@@ -27,7 +27,7 @@ function transportMethod(method) {
             const queueItem = {
                 method,
                 args: transportCallArguments,
-                serviceGroup: transportCallArguments[0],
+                servicePath: transportCallArguments[0],
                 urlTemplate: transportCallArguments[1],
                 urlArgs: transportCallArguments[2],
                 options: transportCallArguments[3],


### PR DESCRIPTION
Capability to configure particular services as cloud services. This sends them to `/oapi` rather than `/openapi`, and excepts them from HTTP-level batching.

```javascript
new SomethingTransport('https://www.saxotrader.com', {
  services: {
    'fooservice': { useCloud: true }  
  }
});
```

Service groups don't exist in the cloud so it's no longer universal. It only remains as a concept in the batch transport for on-prem only. Elsewhere it's just a path string with no particular meaning, so it's renamed to service path to reflect it could be either a service group or the name of a cloud service (causes a lot of diff noise after the first few commits).

In future we may extend the config with a `useBatching` option to allow our "modern services" to be run on-prem where they probably won't have batching either.

In the possible future case of a new service having the same name as an existing service group, the version can be included in the service path configuration and passed to the client in the service path rather than in the 2nd parameter as is usually done.

Internal references:
* PR: 87223
* Wiki: "Use of /oapi by SaxoTrader"