### PR TITLE
reduce connection delay

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v8.0.2
+- Pure websockets - reconnect immediately on first disconnect
+
 ### v8.0.1
 - Some tweaks to protobuf logging messages and data
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "8.0.1",
+    "version": "8.0.2",
     "engines": {
         "node": ">=4"
     },

--- a/src/openapi/streaming/connection/transport/websocket-transport.js
+++ b/src/openapi/streaming/connection/transport/websocket-transport.js
@@ -257,7 +257,11 @@ function handleSocketClose(event) {
         return;
     }
 
-    reconnect.call(this);
+    reconnect.call(
+        this,
+        // if this is the first time, try immediately to prevent delay
+        this.reconnectCount === 0,
+    );
 }
 
 function detectNetworkError() {


### PR DESCRIPTION
If there is a random socket disconnect there is no reason to wait 2s before disconnecting on the first disconnect.

After that its important we wait as we only retry x number of times and if we don't delay we use up the connection attempts.