### PR TITLE
Send last received message id while reconnecting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v8.0.3
+- Signalr core - send last received message id while reconnecting
+
 ### v8.0.2
 - Pure websockets - reconnect immediately on first disconnect
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "8.0.0",
+  "version": "8.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "8.0.2",
+    "version": "8.0.3",
     "engines": {
         "node": ">=4"
     },

--- a/src/openapi/streaming/connection/transport/signalr-core-transport.js
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.js
@@ -33,7 +33,7 @@ function buildConnection({
 }) {
     let queryString = `contextId=${contextId}`;
     if (messageId) {
-        queryString = `${queryString}&&messageId=${messageId}`;
+        queryString = `${queryString}&messageId=${messageId}`;
     }
 
     const url = `${baseUrl}/streaming?${queryString}`;

--- a/src/openapi/streaming/connection/transport/signalr-core-transport.js
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.js
@@ -354,10 +354,10 @@ SignalrCoreTransport.prototype.handleNextMessage = function(message, protocol) {
 
     try {
         const normalizedMessage = normalizeMessage(message, protocol);
-        const parsedMessage = parseMessage(normalizedMessage, this.utf8Decoder);
+        const data = parseMessage(normalizedMessage, this.utf8Decoder);
 
-        this.receivedCallback(parsedMessage);
-        this.lastMessageId = parseMessage.MessageId;
+        this.lastMessageId = data.MessageId;
+        this.receivedCallback(data);
     } catch (error) {
         const errorMessage = error.message || '';
         log.error(

--- a/src/openapi/streaming/connection/transport/signalr-core-transport.spec.js
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.spec.js
@@ -512,7 +512,7 @@ describe('openapi SignalR core Transport', () => {
                 })
                 .then(() => {
                     expect(streamingUrl).toBe(
-                        `${BASE_URL}/streaming?contextId=${CONTEXT_ID}&&messageId=${messageId}`,
+                        `${BASE_URL}/streaming?contextId=${CONTEXT_ID}&messageId=${messageId}`,
                     );
 
                     expect(spyOnStateChangedCallback).toHaveBeenLastCalledWith(

--- a/src/openapi/streaming/connection/transport/signalr-core-transport.spec.js
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.spec.js
@@ -30,10 +30,12 @@ describe('openapi SignalR core Transport', () => {
     let mockRenewToken;
     let mockConnectionClose;
     let tokenFactory;
+    let streamingUrl;
 
     class MockConnectionBuilder {
         withUrl(url, options) {
             tokenFactory = options.accessTokenFactory;
+            streamingUrl = url;
 
             return this;
         }
@@ -463,6 +465,7 @@ describe('openapi SignalR core Transport', () => {
     });
 
     describe('reconnect', () => {
+        const messageId = 10;
         let transport;
         let startPromise;
 
@@ -474,6 +477,7 @@ describe('openapi SignalR core Transport', () => {
                 subscribeNextHandler({
                     PayloadFormat: 1,
                     Payload: window.btoa('{ "a": 2 }'),
+                    MessageId: messageId,
                 }),
             );
 
@@ -484,6 +488,9 @@ describe('openapi SignalR core Transport', () => {
         it('should reconnect on connection close', (done) => {
             startPromise
                 .then(() => {
+                    expect(streamingUrl).toBe(
+                        `${BASE_URL}/streaming?contextId=${CONTEXT_ID}`,
+                    );
                     expect(spyOnStateChangedCallback).toHaveBeenCalledWith(
                         constants.CONNECTION_STATE_CONNECTED,
                     );
@@ -504,6 +511,10 @@ describe('openapi SignalR core Transport', () => {
                     return new Promise((resolve) => setImmediate(resolve));
                 })
                 .then(() => {
+                    expect(streamingUrl).toBe(
+                        `${BASE_URL}/streaming?contextId=${CONTEXT_ID}&&messageId=${messageId}`,
+                    );
+
                     expect(spyOnStateChangedCallback).toHaveBeenLastCalledWith(
                         constants.CONNECTION_STATE_CONNECTED,
                     );

--- a/src/openapi/streaming/streaming.js
+++ b/src/openapi/streaming/streaming.js
@@ -19,6 +19,7 @@ import * as streamingTransports from './connection/transportTypes';
 const OPENAPI_CONTROL_MESSAGE_PREFIX = '_';
 const OPENAPI_CONTROL_MESSAGE_HEARTBEAT = '_heartbeat';
 const OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS = '_resetsubscriptions';
+const OPENAPI_CONTROL_MESSAGE_RECONNECT = '_reconnect';
 
 const DEFAULT_CONNECT_RETRY_DELAY = 1000;
 
@@ -362,6 +363,11 @@ function handleControlMessage(message) {
                 this,
                 getTargetReferenceIds(message),
             );
+            break;
+
+        case OPENAPI_CONTROL_MESSAGE_RECONNECT:
+            // try reconnecting with new context id
+            this.disconnect();
             break;
 
         default:


### PR DESCRIPTION
This PR modifies reconnection logic to send last received message id while reconnecting.
Last received message id is sent as query string while trying to reconnect again.
Server will return _reconnect control message if session is not found while trying to reconnect. In this case client will disconnect and try to reconnect with new context id.