### PR TITLE
Bug fix rounding decimals formatters

### DIFF
--- a/src/number-formatting/format.js
+++ b/src/number-formatting/format.js
@@ -99,7 +99,6 @@ function expandNumber(number, precision, options) {
 
 function roundNumber(number, decimals) {
     // Shift with exponential notation to avoid floating-point issues.
-    // See [MDN](https://mdn.io/round#Examples) for more details.
     let pair = `${number}e`.split('e');
     const value = Math.round(`${pair[0]}e${Number(pair[1]) + decimals}`);
     pair = `${value}e`.split('e');

--- a/src/number-formatting/format.js
+++ b/src/number-formatting/format.js
@@ -11,6 +11,11 @@ function formatNegativeNumber(str, options) {
     return options.negativePattern.replace('{0}', str);
 }
 
+function isScientificNotation(number) {
+    const numberString = String(number);
+    return /\d+\.?\d*e[+-]*\d+/i.test(numberString);
+}
+
 /**
  * converts a number to a decimal string if it is on scientific notation
  * @param number
@@ -19,7 +24,7 @@ function convertNumbertToString(number, precision) {
     let numberString = String(number);
 
     // if the number is in scientific notation, convert to decimal
-    if (/\d+\.?\d*e[+-]*\d+/i.test(numberString)) {
+    if (isScientificNotation(number)) {
         numberString = number.toFixed(precision).trim('0');
     }
 
@@ -33,12 +38,7 @@ function convertNumbertToString(number, precision) {
  * @param { groupSizes, groupSeparator, decimalSeparator, isHideZeroTail } options
  */
 function expandNumber(number, precision, options) {
-    const {
-        groupSizes,
-        groupSeparator,
-        decimalSeparator,
-        isHideZeroTail,
-    } = options;
+    const { groupSizes, groupSeparator, decimalSeparator, isHideZeroTail } = options;
     let curSize = groupSizes[0];
     let curGroupIndex = 1;
     let numberString = convertNumbertToString(number, precision);
@@ -76,10 +76,7 @@ function expandNumber(number, precision, options) {
         if (curSize === 0 || curSize > stringIndex) {
             if (ret.length > 0) {
                 return (
-                    numberString.slice(0, stringIndex + 1) +
-                    groupSeparator +
-                    ret +
-                    right
+                    numberString.slice(0, stringIndex + 1) + groupSeparator + ret + right
                 );
             }
 
@@ -92,10 +89,7 @@ function expandNumber(number, precision, options) {
                 groupSeparator +
                 ret;
         } else {
-            ret = numberString.slice(
-                stringIndex - curSize + 1,
-                stringIndex + 1,
-            );
+            ret = numberString.slice(stringIndex - curSize + 1, stringIndex + 1);
         }
 
         stringIndex -= curSize;
@@ -105,9 +99,24 @@ function expandNumber(number, precision, options) {
             curGroupIndex++;
         }
     }
-    return (
-        numberString.slice(0, stringIndex + 1) + groupSeparator + ret + right
-    );
+    return numberString.slice(0, stringIndex + 1) + groupSeparator + ret + right;
+}
+
+// Does AwayFromZero rounding as per C# - see MidpointRound.AwayFromZero
+// When a number is halfway between two others, it is rounded toward the nearest number that is away from zero.
+// We do this by rounding the absolute number, so it always goes away from zero.
+function roundNumber(number, decimals) {
+    const factor = Math.pow(10, decimals);
+    const absoluteNumber = Math.abs(number);
+    const isScientificNotationNumber = isScientificNotation(absoluteNumber);
+
+    // for not exponential numbers we use exponential rounding to avoid binary floating-point issue like 1.005 * 100 !== 100.5
+    if (isScientificNotationNumber) {
+        return Math.round(absoluteNumber * factor) / factor;
+    }
+    const roundedNumber = Math.round(`${absoluteNumber}e${decimals}`);
+
+    return Number(`${roundedNumber}e-${decimals}`);
 }
 
 // -- Exported methods section --
@@ -117,18 +126,9 @@ function formatNumber(inputNumber, decimals, options) {
         return '';
     }
 
-    // Does AwayFromZero rounding as per C# - see MidpointRound.AwayFromZero
-    // When a number is halfway between two others, it is rounded toward the nearest number that is away from zero.
-    // We do this by rounding the absolute number, so it always goes away from zero.
-    const factor = Math.pow(10, decimals);
-    let absoluteNumber = Math.abs(inputNumber);
-    absoluteNumber = Math.round(absoluteNumber * factor) / factor;
+    const absoluteNumber = roundNumber(inputNumber, decimals);
 
-    let formattedNumber = expandNumber(
-        Math.abs(absoluteNumber),
-        decimals,
-        options,
-    );
+    let formattedNumber = expandNumber(Math.abs(absoluteNumber), decimals, options);
 
     // if the original is negative and it hasn't been rounded to 0
     if (inputNumber < 0 && absoluteNumber !== 0) {

--- a/src/price-formatting/format.spec.js
+++ b/src/price-formatting/format.spec.js
@@ -25,6 +25,7 @@ describe('price-formatting format', () => {
         expect(priceFormatting.format(0, 8)).toEqual('0.00000000');
 
         expect(priceFormatting.format(1.23451, 2)).toEqual('1.23');
+        expect(priceFormatting.format(1.005, 2)).toEqual('1.01');
         expect(priceFormatting.format(-1.23451, 2)).toEqual('-1.23');
 
         expect(priceFormatting.format(1.23451, 4)).toEqual('1.2345');


### PR DESCRIPTION
**Desription**
For some numbers when calling format functions (ex: priceFormatting.format), the number was rounded down while it should be up. 
Example: 
priceFormatting.format(1.005, 2) is returning 1.00 while it should be 1.01.

The issue is caused by binary floating-point representation. 
Example: 
- 0.1 + 0.2 !== 0.3
- 1.005 * 100 = 100.49999999999999

More about it:
https://www.codemag.com/Article/1811041/JavaScript-Corner-Math-and-the-Pitfalls-of-Floating-Point-Numbers

**Solution**
Changing the rounding to use the numbers represented in exponential notation.
http://www.jacklmoore.com/notes/rounding-in-javascript/

Example:
1.005 * 100 is converted to 1.005e2 which gives us 100.5 in a non exponential notation.

**Test**
Added unit test for the above example priceFormatting.format(1.005, 2).
All existing tests are passing.
