### PR TITLE
Allow useCloud to be a function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v8.1.0
+- Allow `useCloud` option to be a function
+
 ### v8.0.6
 - Revert rounding fix introduced in v8.0.5
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/openapi/transport/batch.js
+++ b/src/openapi/transport/batch.js
@@ -10,6 +10,7 @@ import { getRequestId } from '../../utils/request';
 import { formatUrl } from '../../utils/string';
 import { parse as parseBatch, build as buildBatch } from '../batch-util';
 import log from '../../log';
+import { shouldUseCloud } from './options';
 import TransportQueue from './queue';
 
 const reUrl = /((https?:)?\/\/)?[^/]+(.*)/i;
@@ -241,9 +242,7 @@ TransportBatch.prototype.addToQueue = function(item) {
  * @param item
  */
 TransportBatch.prototype.shouldQueue = function(item) {
-    const serviceOptions = this.services[item.servicePath] || {};
-
-    return !serviceOptions.useCloud;
+    return !shouldUseCloud(this.services[item.servicePath]);
 };
 
 /**

--- a/src/openapi/transport/core.js
+++ b/src/openapi/transport/core.js
@@ -6,6 +6,7 @@
 import { formatUrl } from '../../utils/string';
 import fetch from '../../utils/fetch';
 import { getRequestId } from '../../utils/request';
+import { shouldUseCloud } from './options';
 
 // -- Local variables section --
 
@@ -53,8 +54,7 @@ function generateTransportCall(method) {
                 (options && options.requestId) || getRequestId();
         }
 
-        const serviceOptions = this.services[servicePath] || {};
-        const basePath = serviceOptions.useCloud ? '/oapi' : '/openapi';
+        const basePath = shouldUseCloud(this.services[servicePath]) ? '/oapi' : '/openapi';
 
         return this.fetch(
             method,
@@ -75,7 +75,7 @@ function generateTransportCall(method) {
  * Options pertaining to a specific service path.
  *
  * @typedef {Object} saxo.ServiceOptions
- * @property {boolean} [useCloud] - Request from OpenAPI cloud (/oapi)
+ * @property {boolean|function} [useCloud] - Request from OpenAPI cloud (/oapi)
  */
 
 /**

--- a/src/openapi/transport/core.spec.js
+++ b/src/openapi/transport/core.spec.js
@@ -99,7 +99,7 @@ describe('openapi TransportCore', () => {
             );
         });
 
-        it.only('allows useCloud configuration to be dynamic', () => {
+        it('allows useCloud configuration to be dynamic', () => {
             const useCloud = jest.fn();
             transport = new TransportCore('localhost', {
                 services: {

--- a/src/openapi/transport/core.spec.js
+++ b/src/openapi/transport/core.spec.js
@@ -98,6 +98,34 @@ describe('openapi TransportCore', () => {
                 expect.anything(),
             );
         });
+
+        it.only('allows useCloud configuration to be dynamic', () => {
+            const useCloud = jest.fn();
+            transport = new TransportCore('localhost', {
+                services: {
+                    service_path: { useCloud },
+                },
+            });
+
+            useCloud.mockReturnValue(false);
+            transport.get('service_path', 'endpoint');
+
+            expect(useCloud).toHaveBeenCalled();
+            expect(fetch).toHaveBeenCalledWith(
+                'localhost/openapi/service_path/endpoint',
+                expect.anything(),
+            );
+
+            fetch.mockClear();
+            useCloud.mockReturnValue(true);
+            transport.get('service_path', 'endpoint');
+
+            expect(useCloud).toHaveBeenCalled();
+            expect(fetch).toHaveBeenCalledWith(
+                'localhost/oapi/service_path/endpoint',
+                expect.anything(),
+            );
+        });
     });
 
     describe('url templating', () => {

--- a/src/openapi/transport/options.js
+++ b/src/openapi/transport/options.js
@@ -1,0 +1,20 @@
+/**
+ * @module saxo/openapi/transport/options
+ * @ignore
+ */
+
+// -- Local variables section --
+
+// -- Local methods section --
+
+// -- Exported methods section --
+
+function shouldUseCloud(serviceOptions) {
+    const { useCloud } = serviceOptions || {};
+
+    return typeof useCloud === 'function' ? useCloud() : useCloud;
+}
+
+// -- Export section --
+
+export { shouldUseCloud };


### PR DESCRIPTION
Support the use case of gradual rollout of a replacement service having the same servicePath.