### PR TITLE
Fix exception in IE11 and token renewal issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### v8.1.1
+- Signalr core - Fixes exception in IE11 if abortController polyfill is not provided
+- Signalr core - Add guard to avoid token renewal request before connection is established
+
 ### v8.1.0
 - Allow `useCloud` option to be a function
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "8.0.4",
+  "version": "8.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "8.1.0",
+    "version": "8.1.1",
     "engines": {
         "node": ">=4"
     },


### PR DESCRIPTION
If consumer app has fetch polyfill for IE11, Signalr core lib tries to use FetchHttpClient for communication which uses AbortController. Unfortunately AbortController is not supported in IE11. Signalr do use ponyfill for AbortController except in FetchHttpClient. I have raise a bug in signalr repo for the same.
https://github.com/dotnet/aspnetcore/issues/29424

This PR also fixes the token renewal issue. It was possible to call renewSession before the connection is established.
The guard is added to check whether connection is established before calling renewSession