### PR TITLE
Fix various minor issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -140,7 +140,7 @@
         "no-self-assign": "error",
         "no-self-compare": "error",
         "no-sequences": "error",
-        "no-throw-literal": "error",
+        "no-throw-literal": "off",
         "no-unmodified-loop-condition": "error",
         "no-unused-expressions": "error",
         "no-unused-labels": "error",

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v8.1.2
+- Better setting of isNetworkError property when fetch fails due to excessive auth errors
+
 ### v8.1.1
 - Signalr core - Fixes exception in IE11 if abortController polyfill is not provided
 - Signalr core - Add guard to avoid token renewal request before connection is established

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "8.1.1",
+    "version": "8.1.2-beta.0",
     "engines": {
         "node": ">=4"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "8.1.2-beta.0",
+    "version": "8.1.2",
     "engines": {
         "node": ">=4"
     },

--- a/src/openapi/transport/auth.js
+++ b/src/openapi/transport/auth.js
@@ -60,8 +60,6 @@ function onTransportError(oldTokenExpiry, timeRequested, result) {
             );
             throw {
                 message: 'Auth overload',
-                // obscure the real status code so that the queue does not keep retrying
-                status: 500,
                 isNetworkError: false,
             };
         }

--- a/src/openapi/transport/auth.spec.js
+++ b/src/openapi/transport/auth.spec.js
@@ -283,7 +283,6 @@ describe('openapi TransportAuth', () => {
                             Object {
                               "isNetworkError": false,
                               "message": "Auth overload",
-                              "status": 500,
                             },
                           ],
                         ]

--- a/src/openapi/transport/auth.spec.js
+++ b/src/openapi/transport/auth.spec.js
@@ -225,10 +225,12 @@ describe('openapi TransportAuth', () => {
                 ],
             ).toBe(undefined);
 
+            const catchError = jest.fn();
+
             return waterfallTimeout([
                 () => {
                     authProvider.getExpiry.mockImplementation(() => 1);
-                    transportAuth.post('service_path', 'url').catch(noop);
+                    transportAuth.post('service_path', 'url').catch(catchError);
                     transportAuth.state = 1;
                     fetch.resolve(401, {
                         error: 401,
@@ -245,7 +247,7 @@ describe('openapi TransportAuth', () => {
                 },
                 () => {
                     authProvider.getExpiry.mockImplementation(() => 2);
-                    transportAuth.post('service_path', 'url').catch(noop);
+                    transportAuth.post('service_path', 'url').catch(catchError);
                     transportAuth.state = 1;
                     fetch.resolve(401, {
                         error: 401,
@@ -259,6 +261,33 @@ describe('openapi TransportAuth', () => {
                             'localhost/openapi/service_path/url'
                         ],
                     ).toEqual([expect.any(Object), expect.any(Object)]);
+                    expect(catchError).toHaveBeenCalledTimes(2);
+                    expect(catchError.mock.calls).toMatchInlineSnapshot(`
+                        Array [
+                          Array [
+                            Object {
+                              "headers": Object {
+                                "get": [Function],
+                              },
+                              "response": Object {
+                                "error": 401,
+                                "message": "Authorization exception",
+                              },
+                              "responseType": "json",
+                              "size": 49,
+                              "status": 401,
+                              "url": "localhost/openapi/service_path/url",
+                            },
+                          ],
+                          Array [
+                            Object {
+                              "isNetworkError": false,
+                              "message": "Auth overload",
+                              "status": 500,
+                            },
+                          ],
+                        ]
+                    `);
 
                     done();
                 },

--- a/src/openapi/transport/batch.js
+++ b/src/openapi/transport/batch.js
@@ -37,7 +37,11 @@ function emptyQueueIntoServiceGroups() {
 function batchCallFailure(callList, batchResponse) {
     const isAuthFailure = batchResponse && batchResponse.status === 401;
     const isNetworkError =
-        !batchResponse || batchResponse.isNetworkError || !batchResponse.status;
+        !batchResponse ||
+        // Some responses same to be in error but not have isNetworkError defined
+        (typeof batchResponse.isNetworkError === 'boolean'
+            ? batchResponse.isNetworkError
+            : !batchResponse.status);
 
     const logFunction = isAuthFailure || isNetworkError ? log.debug : log.error;
     logFunction(LOG_AREA, 'Batch request failed', batchResponse);

--- a/src/openapi/transport/batch.spec.js
+++ b/src/openapi/transport/batch.spec.js
@@ -723,27 +723,124 @@ describe('openapi TransportBatch', () => {
             // put in here in case it changes and we decide to reject with something
             expect(getCatch.mock.calls.length).toEqual(1);
             expect(getCatch.mock.calls[0]).toEqual([
-                { message: 'batch failed' },
+                { message: 'batch failed', isNetworkError: false },
             ]);
 
             expect(putCatch.mock.calls.length).toEqual(1);
             expect(putCatch.mock.calls[0]).toEqual([
-                { message: 'batch failed' },
+                { message: 'batch failed', isNetworkError: false },
             ]);
 
             expect(postCatch.mock.calls.length).toEqual(1);
             expect(postCatch.mock.calls[0]).toEqual([
-                { message: 'batch failed' },
+                { message: 'batch failed', isNetworkError: false },
             ]);
 
             expect(deleteCatch.mock.calls.length).toEqual(1);
             expect(deleteCatch.mock.calls[0]).toEqual([
-                { message: 'batch failed' },
+                { message: 'batch failed', isNetworkError: false },
             ]);
 
             expect(patchCatch.mock.calls.length).toEqual(1);
             expect(patchCatch.mock.calls[0]).toEqual([
-                { message: 'batch failed' },
+                { message: 'batch failed', isNetworkError: false },
+            ]);
+
+            done();
+        });
+    });
+
+    it('passes on network errors', function(done) {
+        transportBatch = new TransportBatch(transport, validBaseUrl, {
+            timeoutMs: 0,
+        });
+        const getPromise = transportBatch.get(
+            'port',
+            'ref/v1/instruments/details/{InstrumentId}/{Type}',
+            {
+                InstrumentId: 1518824,
+                Type: 'CfdOnFutures',
+            },
+        );
+        const putPromise = transportBatch.put(
+            'port',
+            'ref/v1/instruments/details/{InstrumentId}/{Type}',
+            {
+                InstrumentId: 1518824,
+                Type: 'CfdOnFutures',
+            },
+        );
+        const postPromise = transportBatch.post(
+            'port',
+            'ref/v1/instruments/details/{InstrumentId}/{Type}',
+            {
+                InstrumentId: 1518824,
+                Type: 'CfdOnFutures',
+            },
+        );
+        const deletePromise = transportBatch.delete(
+            'port',
+            'ref/v1/instruments/details/{InstrumentId}/{Type}',
+            {
+                InstrumentId: 1518824,
+                Type: 'CfdOnFutures',
+            },
+        );
+        const patchPromise = transportBatch.patch(
+            'port',
+            'ref/v1/instruments/details/{InstrumentId}/{Type}',
+            {
+                InstrumentId: 1518824,
+                Type: 'CfdOnFutures',
+            },
+        );
+
+        tick(1);
+
+        expect(transport.post.mock.calls.length).toEqual(1);
+
+        transport.postReject({ isNetworkError: true });
+
+        const getCatch = jest.fn().mockName('getCatch');
+        const putCatch = jest.fn().mockName('putCatch');
+        const postCatch = jest.fn().mockName('postCatch');
+        const deleteCatch = jest.fn().mockName('deleteCatch');
+        const patchCatch = jest.fn().mockName('patchCatch');
+
+        getPromise.catch(getCatch);
+        putPromise.catch(putCatch);
+        postPromise.catch(postCatch);
+        deletePromise.catch(deleteCatch);
+        patchPromise.catch(patchCatch);
+
+        tick(1);
+
+        setTimeout(() => {
+            // we reject the promise with nothing, which somes through as undefined.
+            // put in here in case it changes and we decide to reject with something
+            expect(getCatch.mock.calls.length).toEqual(1);
+            expect(getCatch.mock.calls[0]).toEqual([
+                { message: 'batch failed', isNetworkError: true },
+            ]);
+
+            expect(putCatch.mock.calls.length).toEqual(1);
+            expect(putCatch.mock.calls[0]).toEqual([
+                { message: 'batch failed', isNetworkError: true },
+            ]);
+
+            expect(postCatch.mock.calls.length).toEqual(1);
+            expect(postCatch.mock.calls[0]).toEqual([
+                { message: 'batch failed', isNetworkError: true },
+            ]);
+
+            expect(deleteCatch.mock.calls.length).toEqual(1);
+            expect(deleteCatch.mock.calls[0]).toEqual([
+                { message: 'batch failed', isNetworkError: true },
+            ]);
+
+            expect(patchCatch.mock.calls.length).toEqual(1);
+            expect(patchCatch.mock.calls[0]).toEqual([
+                { message: 'batch failed', isNetworkError: true },
             ]);
 
             done();
@@ -806,27 +903,27 @@ describe('openapi TransportBatch', () => {
         setTimeout(() => {
             expect(getCatch.mock.calls.length).toEqual(1);
             expect(getCatch.mock.calls[0]).toEqual([
-                { message: 'batch failed' },
+                { message: 'batch failed', isNetworkError: false },
             ]);
 
             expect(putCatch.mock.calls.length).toEqual(1);
             expect(deleteCatch.mock.calls[0]).toEqual([
-                { message: 'batch failed' },
+                { message: 'batch failed', isNetworkError: false },
             ]);
 
             expect(postCatch.mock.calls.length).toEqual(1);
             expect(postCatch.mock.calls[0]).toEqual([
-                { message: 'batch failed' },
+                { message: 'batch failed', isNetworkError: false },
             ]);
 
             expect(deleteCatch.mock.calls.length).toEqual(1);
             expect(deleteCatch.mock.calls[0]).toEqual([
-                { message: 'batch failed' },
+                { message: 'batch failed', isNetworkError: false },
             ]);
 
             expect(patchCatch.mock.calls.length).toEqual(1);
             expect(patchCatch.mock.calls[0]).toEqual([
-                { message: 'batch failed' },
+                { message: 'batch failed', isNetworkError: false },
             ]);
 
             done();

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -44,7 +44,7 @@ export function convertFetchReject(url, body, timerId, error) {
         isNetworkError: true,
     };
 
-    throw networkError;
+    return Promise.reject(networkError);
 }
 
 /**
@@ -164,6 +164,7 @@ export function convertFetchSuccess(url, body, timerId, result) {
                 status: newResult.status,
                 response: newResult.response,
                 requestId: requestId || null,
+                isNetworkError: false,
             });
 
             throw newResult;
@@ -252,10 +253,9 @@ function localFetch(method, url, options) {
         });
     }, 30000);
 
-    return fetch(url, { headers, method, body, credentials }).then(
-        convertFetchSuccess.bind(null, url, body, timerId),
-        convertFetchReject.bind(null, url, body, timerId),
-    );
+    return fetch(url, { headers, method, body, credentials })
+        .catch(convertFetchReject.bind(null, url, body, timerId))
+        .then(convertFetchSuccess.bind(null, url, body, timerId));
 }
 
 // Check for handled type: https://fetch.spec.whatwg.org/#bodyinit

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -143,7 +143,10 @@ export function convertFetchSuccess(url, body, timerId, result) {
             });
     }
 
-    if ((result.status < 200 || result.status > 299) && result.status !== 304) {
+    if (
+        !result.status ||
+        ((result.status < 200 || result.status > 299) && result.status !== 304)
+    ) {
         convertedPromise = convertedPromise.then((newResult) => {
             const correlation = result.headers.get('x-correlation') || '';
 


### PR DESCRIPTION
From analyzing logs on live I've found some bugs - primarily the problem is that isNetworkError is false when it should be true for alot of batch requests.

When I found the issue, I realised that we should not be getting this error at all under normal operation, so analysing that I found that when calls are delayed it can trigger the authorisation error overload when the calls were dispatched many minutes apart. So I fixed that by debouncing calls based on the time from when the request starts.