### PR TITLE
Handle reset better

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v8.1.3
+- Handle reset messages better
+
 ### v8.1.2
 - Better setting of isNetworkError property when fetch fails due to excessive auth errors
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "8.1.3-reset.0",
+    "version": "8.1.2",
     "engines": {
         "node": ">=4"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "8.1.2",
+    "version": "8.1.3-reset.0",
     "engines": {
         "node": ">=4"
     },

--- a/src/openapi/streaming/subscription-actions.js
+++ b/src/openapi/streaming/subscription-actions.js
@@ -3,9 +3,3 @@ export const ACTION_UNSUBSCRIBE = 0x2;
 export const ACTION_MODIFY = 0x4;
 export const ACTION_MODIFY_PATCH = 0x8;
 export const ACTION_UNSUBSCRIBE_BY_TAG_PENDING = 0x10;
-
-// Subscrtiption action variant that drives queue merging logic for subscription modification.
-// Whenever ACTION_UNSUBSCRIBE is followed by ACTION_MODIFY_SUBSCRIBE, both actions will be kept.
-// However if ACTION_UNSUBSCRIBE is followed by ACTION_SUBSCRIBE, we drop ACTION_UNSUBSCRIBE.
-// Above cases only matter in context of pending actions queue.
-export const ACTION_MODIFY_SUBSCRIBE = ACTION_SUBSCRIBE | ACTION_MODIFY;

--- a/src/openapi/streaming/subscription-queue.js
+++ b/src/openapi/streaming/subscription-queue.js
@@ -10,7 +10,6 @@
 import {
     ACTION_SUBSCRIBE,
     ACTION_UNSUBSCRIBE,
-    ACTION_MODIFY_SUBSCRIBE,
     ACTION_MODIFY_PATCH,
     ACTION_UNSUBSCRIBE_BY_TAG_PENDING,
 } from './subscription-actions';
@@ -47,42 +46,81 @@ SubscriptionQueue.prototype.enqueue = function(queuedItem) {
     }
 
     const { action } = queuedItem;
-    const prevAction = getLastItem.call(this).action;
+    const prevItem = getLastItem.call(this);
+    const prevAction = prevItem.action;
 
-    // ..UM => UM
-    if (action === ACTION_MODIFY_SUBSCRIBE) {
-        if (prevAction === ACTION_UNSUBSCRIBE) {
-            this.items = [{ action: ACTION_UNSUBSCRIBE }, queuedItem];
-        }
-        return;
-    }
-
-    // MM => M, UU => U, SS => S
+    // unless its a patch, doing the same thing twice is a noop
     if (action === prevAction && action !== ACTION_MODIFY_PATCH) {
+        // if its a unsubscribe, make sure the forces get joined
+        if (
+            action === ACTION_UNSUBSCRIBE &&
+            queuedItem.args.force &&
+            !prevItem.args.force
+        ) {
+            prevItem.args.force = true;
+        }
+
         return;
     }
 
-    // MS => M
-    if (prevAction === ACTION_MODIFY_SUBSCRIBE && action === ACTION_SUBSCRIBE) {
-        return;
-    }
-
-    // US => S
-    // SU => U
     if (
-        (prevAction === ACTION_UNSUBSCRIBE && action === ACTION_SUBSCRIBE) ||
-        (prevAction === ACTION_SUBSCRIBE && action === ACTION_UNSUBSCRIBE) ||
+        // only remove the unsubscribe if it is not a forced unsubscribe
+        (prevAction === ACTION_UNSUBSCRIBE &&
+            action === ACTION_SUBSCRIBE &&
+            !prevItem.args.force) ||
+        // unsubscribing when a subscribe is queued can always eliminate the subscribe
+        (prevAction === ACTION_SUBSCRIBE &&
+            (action === ACTION_UNSUBSCRIBE ||
+                action === ACTION_UNSUBSCRIBE_BY_TAG_PENDING)) ||
+        // unsubscribing when we need to patch can happen if we are sure the unsubscribe will happen
+        (prevAction === ACTION_MODIFY_PATCH &&
+            ((action === ACTION_UNSUBSCRIBE && queuedItem.args.force) ||
+                action === ACTION_UNSUBSCRIBE_BY_TAG_PENDING)) ||
+        // We can switch a force unsubscribe for a unsubscribe by tag because there is no logic
+        // to remove the unsubscribe by tag if its followed by a subscribe...
         (prevAction === ACTION_UNSUBSCRIBE &&
             action === ACTION_UNSUBSCRIBE_BY_TAG_PENDING)
     ) {
         this.items.splice(-1);
+
+        // try again - this allows us to remove multiple items
+        // e.g.
+        // unsubscribe force
+        // subscribe
+        // unsubscribe (/by tag)
+        this.enqueue(queuedItem);
+        return;
     }
 
     this.items.push(queuedItem);
 };
 
 /**
- * Returns the action from the beggining of a queue without removing it.
+ * This is called at the point of subscribing.
+ * We know at that point we do not need any follow up patches
+ * or subscribes.
+ */
+SubscriptionQueue.prototype.clearPatches = function() {
+    const newItems = [];
+    let reachedNonPatchSubscribe = false;
+    for (let i = 0; i < this.items.length; i++) {
+        const action = this.items[i].action;
+        if (
+            !reachedNonPatchSubscribe &&
+            action !== ACTION_SUBSCRIBE &&
+            action !== ACTION_MODIFY_PATCH
+        ) {
+            // The unit tests don't hit this and I can't think of a way they would
+            // but I'm keeping it in because I'm not fully confident we can just reset the list
+            newItems.push(this.items[i]);
+            reachedNonPatchSubscribe = true;
+        }
+    }
+    this.items = newItems;
+};
+
+/**
+ * Returns the action from the beginning of a queue without removing it.
  * @return {Number} Next action.
  */
 SubscriptionQueue.prototype.peekAction = function() {
@@ -106,31 +144,18 @@ SubscriptionQueue.prototype.dequeue = function() {
     if (this.isEmpty()) {
         return nextItem;
     }
-    const nextAction = nextItem.action;
-    const lastItem = getLastItem.call(this);
-    const lastAction = lastItem.action;
 
-    if (
-        nextAction === ACTION_MODIFY_SUBSCRIBE &&
-        lastAction !== ACTION_UNSUBSCRIBE
-    ) {
-        // M, U, S => M
-        // M, U, M, U, M => M
-        // M, P, P => M
-        this.reset();
-        return nextItem;
-    }
-
-    if (
-        lastAction === ACTION_UNSUBSCRIBE ||
-        lastAction === ACTION_UNSUBSCRIBE_BY_TAG_PENDING
-    ) {
-        // M, U, S, U => U
-        // S, U => U
-        // S, U, S, U => U
-        // P, U => U
-        this.reset();
-        return lastItem;
+    // because there might be a modify patch at the end, we see if there is a unsubscribe somewhere in the queue
+    for (let i = this.items.length - 1; i >= 0; i--) {
+        const item = this.items[i];
+        const { action } = item;
+        if (
+            action === ACTION_UNSUBSCRIBE ||
+            action === ACTION_UNSUBSCRIBE_BY_TAG_PENDING
+        ) {
+            this.items = this.items.slice(i + 1);
+            return item;
+        }
     }
 
     return nextItem;

--- a/src/openapi/streaming/subscription-queue.spec.js
+++ b/src/openapi/streaming/subscription-queue.spec.js
@@ -22,6 +22,27 @@ describe('openapi SubscriptionQueue', () => {
             );
             expect(queue.isEmpty()).toBe(false);
         });
+    });
+
+    describe('enqueue & dequeue', () => {
+        beforeEach(() => {
+            queue = new SubscriptionQueue();
+        });
+
+        const tests = [
+            [
+                'should merge same actions - subscribe',
+                [
+                    SubscriptionActions.ACTION_SUBSCRIBE,
+                    SubscriptionActions.ACTION_SUBSCRIBE,
+                ],
+                [SubscriptionActions.ACTION_SUBSCRIBE],
+            ],
+        ];
+
+        tests.forEach(([title, actionsToQueue, expectedActions]) => {
+            it(title, () => {});
+        });
 
         it('should merge same actions', () => {
             queue.enqueue({ action: SubscriptionActions.ACTION_SUBSCRIBE });
@@ -451,12 +472,6 @@ describe('openapi SubscriptionQueue', () => {
                 SubscriptionActions.ACTION_UNSUBSCRIBE_BY_TAG_PENDING,
             );
             expect(queue.isEmpty()).toBe(true);
-        });
-    });
-
-    describe('dequeue', () => {
-        beforeEach(() => {
-            queue = new SubscriptionQueue();
         });
 
         it('should dequeue first and only action and leave queue empty', () => {


### PR DESCRIPTION
1. When we get a reset, unsubscribe and wait for that subscribe to finish before subscribing again
2. As a side effect - resets occurrring whilst unsubscribing have no effect
3. Because we could be in the process of subscribing so unsure if the subscription is reset or not.. we need to make sure we force a unsubscribe - so added a force option to unsubscribe
4. The force option on unsubscribe is the same as the existing modify_subscribe logic - its achieving the same thing by making sure a unsubscribe/subscribe happens. So remove that action type and rely on force unsubscribe.
5. Re-write the queue to handle this. Also try and reduce calls that might happen because we get a modify patch when in the unsubscribed state