### PR TITLE
Bug rounding number

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v8.2.2
+- Fix rounding numbers
+
 ### v8.2.1
 - Fix cloud streaming fallback
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "8.2.1",
+    "version": "8.2.2",
     "engines": {
         "node": ">=4"
     },

--- a/src/number-formatting/format.js
+++ b/src/number-formatting/format.js
@@ -110,6 +110,15 @@ function expandNumber(number, precision, options) {
     );
 }
 
+function roundNumber(number, decimals) {
+    // Shift with exponential notation to avoid floating-point issues.
+    let pair = `${number}e`.split('e');
+    const value = Math.round(`${pair[0]}e${Number(pair[1]) + decimals}`);
+    const factor = Math.pow(10, decimals);
+
+    return value / factor;
+}
+
 // -- Exported methods section --
 
 function formatNumber(inputNumber, decimals, options) {
@@ -120,18 +129,13 @@ function formatNumber(inputNumber, decimals, options) {
     // Does AwayFromZero rounding as per C# - see MidpointRound.AwayFromZero
     // When a number is halfway between two others, it is rounded toward the nearest number that is away from zero.
     // We do this by rounding the absolute number, so it always goes away from zero.
-    const factor = Math.pow(10, decimals);
-    let absoluteNumber = Math.abs(inputNumber);
-    absoluteNumber = Math.round(absoluteNumber * factor) / factor;
+    const absoluteNumber = Math.abs(inputNumber);
+    const roundedNumber = roundNumber(absoluteNumber, decimals);
 
-    let formattedNumber = expandNumber(
-        Math.abs(absoluteNumber),
-        decimals,
-        options,
-    );
+    let formattedNumber = expandNumber(Math.abs(roundedNumber), decimals, options);
 
     // if the original is negative and it hasn't been rounded to 0
-    if (inputNumber < 0 && absoluteNumber !== 0) {
+    if (inputNumber < 0 && roundedNumber !== 0) {
         formattedNumber = formatNegativeNumber(formattedNumber, options);
     }
 

--- a/src/price-formatting/format.spec.js
+++ b/src/price-formatting/format.spec.js
@@ -29,12 +29,16 @@ describe('price-formatting format', () => {
 
         expect(priceFormatting.format(1.23451, 4)).toEqual('1.2345');
         expect(priceFormatting.format(1.23451, 5)).toEqual('1.23451');
+        expect(priceFormatting.format(1.005, 2)).toEqual('1.01');
 
         expect(priceFormatting.format(1234567.23451, 4)).toEqual(
             '1,234,567.2345',
         );
         expect(priceFormatting.format(-1234567.23451, 4)).toEqual(
             '-1,234,567.2345',
+        );
+        expect(priceFormatting.format(1991841981440.0645, 8)).toEqual(
+            '1,991,841,981,440.06450000',
         );
 
         expect(priceFormatting.format(5e-7, 7)).toEqual('0.0000005');


### PR DESCRIPTION
**Desription**
For some numbers when calling format functions (ex: priceFormatting.format), the number was rounded down while it should be up.
**Example:**
priceFormatting.format(1.005, 2) is returning 1.00 while it should be 1.01.

The issue is caused by binary floating-point representation.
**Example:**
0.1 + 0.2 !== 0.3
1.005 * 100 = 100.49999999999999
More about it:
https://www.codemag.com/Article/1811041/JavaScript-Corner-Math-and-the-Pitfalls-of-Floating-Point-Numbers

**Solution**
Changing the rounding to use the numbers represented in exponential notation. First multiply using exponential notation, round, and then divide by numeric factor representation

**Example:**
1.005 with 2 decimals is converted to 1.005e2 which gives us 100.5 in a non exponential notation, rounded to 101, and then divided by the numeric factor representation (101 / 100 = 1.01).

**Tests**
Added unit test for wrongly rounded numbers
All existing tests are passing. Checked also tests from SaxoTrader repo (one test failed although the expected value is wrong and must be corrected).