### PR TITLE
subcribe before streaming is setup

### DIFF
--- a/src/openapi/streaming/subscription.js
+++ b/src/openapi/streaming/subscription.js
@@ -149,6 +149,15 @@ function tryPerformAction(action, args) {
     }
 
     if (
+        this.shouldSubscribeBeforeStreamingSetup &&
+        action === ACTION_SUBSCRIBE &&
+        !this.connectionAvailable
+    ) {
+        performAction.call(this, { action, args });
+        return;
+    }
+
+    if (
         !this.connectionAvailable ||
         this.TRANSITIONING_STATES & this.currentState
     ) {
@@ -660,6 +669,8 @@ function Subscription(
     this.onQueueEmpty = options.onQueueEmpty;
     this.headers = options.headers && extend({}, options.headers);
     this.onNetworkError = options.onNetworkError;
+    this.shouldSubscribeBeforeStreamingSetup =
+        options.shouldSubscribeBeforeStreamingSetup;
 
     if (!this.subscriptionData.RefreshRate) {
         this.subscriptionData.RefreshRate = DEFAULT_REFRESH_RATE_MS;
@@ -684,6 +695,7 @@ Subscription.prototype.STATE_SUBSCRIBED = 0x2;
 Subscription.prototype.STATE_UNSUBSCRIBE_REQUESTED = 0x4;
 Subscription.prototype.STATE_UNSUBSCRIBED = 0x8;
 Subscription.prototype.STATE_PATCH_REQUESTED = 0x10;
+Subscription.prototype.STATE_READY_FOR_UNSUBSCRIBE_BY_TAG = 0x20;
 
 Subscription.prototype.TRANSITIONING_STATES =
     Subscription.prototype.STATE_SUBSCRIBE_REQUESTED |

--- a/src/openapi/streaming/subscription.spec.js
+++ b/src/openapi/streaming/subscription.spec.js
@@ -259,9 +259,9 @@ describe('openapi StreamingSubscription', () => {
                     null,
                     {
                         body: {
-                            RefreshRate: 1000,
                             ContextId: '123',
-                            ReferenceId: '1',
+                            ReferenceId: '10',
+                            RefreshRate: 1000,
                         },
                     },
                 ]);

--- a/src/openapi/streaming/subscription.spec.js
+++ b/src/openapi/streaming/subscription.spec.js
@@ -239,7 +239,7 @@ describe('openapi StreamingSubscription', () => {
         });
 
         describe('accepts shouldSubscribeBeforeStreamingSetup boolean flag', () => {
-            it.only('should subscribe when the connection is unavailable and flag is true', () => {
+            it('should subscribe when the connection is unavailable and flag is true', () => {
                 const subscription = new Subscription(
                     '123',
                     transport,

--- a/src/openapi/streaming/subscription.spec.js
+++ b/src/openapi/streaming/subscription.spec.js
@@ -237,6 +237,36 @@ describe('openapi StreamingSubscription', () => {
                 });
             });
         });
+
+        describe('accepts shouldSubscribeBeforeStreamingSetup boolean flag', () => {
+            it.only('should subscribe when the connection is unavailable and flag is true', () => {
+                const subscription = new Subscription(
+                    '123',
+                    transport,
+                    'servicePath',
+                    'src/test/resource',
+                    {},
+                    null,
+                    { shouldSubscribeBeforeStreamingSetup: true },
+                );
+                subscription.onConnectionUnavailable();
+                subscription.onSubscribe();
+
+                expect(transport.post.mock.calls.length).toEqual(1);
+                expect(transport.post.mock.calls[0]).toEqual([
+                    'servicePath',
+                    'src/test/resource',
+                    null,
+                    {
+                        body: {
+                            RefreshRate: 1000,
+                            ContextId: '123',
+                            ReferenceId: '1',
+                        },
+                    },
+                ]);
+            });
+        });
     });
 
     describe('initial snapshot', () => {


### PR DESCRIPTION
- As of now we queue subscription requests waiting for streaming and only when streaming setup is done we allow it to subscribe.
- setting up streaming connection takes time because of which our subscription also have to wait for it.
- this PR adds an option to pass a Boolean flag **shouldSubscribeBeforeStreamingSetup** while creating a new subscription. 
- when this flag is passed true we will not wait for streaming connection to setup and will subscribe right away. by doing this we can get the initial snapshot response which we can use to render our UI as early as possible.
- later updates will be passed via the streaming channel when its ready
