### PR TITLE
Add option to pass abort signal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v8.4.2
+- Add support for using fetch signal
+
 ### v8.4.0
 - Add pause, resume support to freeze subscriptions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "8.4.0-beta-signal",
+  "version": "8.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "8.4.0",
+  "version": "8.4.0-beta-signal",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "8.4.0-beta-signal",
+    "version": "8.4.2",
     "engines": {
         "node": ">=4"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "8.4.0",
+    "version": "8.4.0-beta-signal",
     "engines": {
         "node": ">=4"
     },

--- a/src/openapi/transport/core.js
+++ b/src/openapi/transport/core.js
@@ -24,6 +24,7 @@ function generateTransportCall(method) {
         let headers = {};
         let cache = this.defaultCache;
         let queryParams;
+        let signal;
 
         if (!servicePath || !urlTemplate) {
             throw new Error('Transport calls require a service path and a URL');
@@ -39,6 +40,7 @@ function generateTransportCall(method) {
             }
 
             queryParams = options.queryParams;
+            signal = options.signal;
         }
 
         const url = formatUrl(urlTemplate, templateArgs, queryParams);
@@ -66,6 +68,7 @@ function generateTransportCall(method) {
                 headers,
                 cache,
                 useXHttpMethodOverride: this.useXHttpMethodOverride,
+                signal,
             },
         );
     };

--- a/src/openapi/transport/core.spec.js
+++ b/src/openapi/transport/core.spec.js
@@ -882,7 +882,7 @@ describe('openapi TransportCore', () => {
         }
 
         it('passes the abort signal down to fetch', () => {
-            const signal = jest.fn().mockName('AbortSignal')
+            const signal = jest.fn().mockName('AbortSignal');
 
             transport.get('service_path', 'url', null, { signal });
             expectFetchToBeCalledWith(signal);

--- a/src/openapi/transport/core.spec.js
+++ b/src/openapi/transport/core.spec.js
@@ -865,4 +865,32 @@ describe('openapi TransportCore', () => {
             fetch.mockClear();
         });
     });
+
+    describe('abort signal', () => {
+        beforeEach(() => {
+            transport = new TransportCore('localhost');
+        });
+
+        afterEach(() => transport.dispose());
+
+        function expectFetchToBeCalledWith(signal) {
+            expect(fetch.mock.calls.length).toEqual(1);
+            expect(fetch.mock.calls[0]).toEqual([
+                expect.anything(),
+                expect.objectContaining({ signal }),
+            ]);
+        }
+
+        it('passes the abort signal down to fetch', () => {
+            const signal = jest.fn().mockName('AbortSignal')
+
+            transport.get('service_path', 'url', null, { signal });
+            expectFetchToBeCalledWith(signal);
+            fetch.mockClear();
+
+            transport.get('service_path', 'url');
+            expectFetchToBeCalledWith(undefined);
+            fetch.mockClear();
+        });
+    });
 });

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -209,6 +209,8 @@ function getBody(method, options) {
  *                                    none will be included.
  *                             "same-origin" will include the cookies if on the same domain (this is the XmlHttpRequest default)
  *                             "include" will always include the cookies.
+ * @param {AbortSignal} [options.signal] - represents a signal object that allows to communicate with Fetch and abort it if required
+ *
  * @return {Promise<{ status: number, response: Object|String, headers: Object },{ status: number, response: Object|String, headers: Object }|Error>}
  */
 function localFetch(method, url, options) {
@@ -217,6 +219,7 @@ function localFetch(method, url, options) {
     const cache = options && options.cache;
     let credentials = options && options.credentials;
     const useXHttpMethodOverride = options && options.useXHttpMethodOverride;
+    const signal = options && options.signal;
 
     if (!credentials) {
         credentials = 'include';
@@ -253,7 +256,7 @@ function localFetch(method, url, options) {
         });
     }, 30000);
 
-    return fetch(url, { headers, method, body, credentials })
+    return fetch(url, { headers, method, body, credentials, signal })
         .catch(convertFetchReject.bind(null, url, body, timerId))
         .then(convertFetchSuccess.bind(null, url, body, timerId));
 }


### PR DESCRIPTION
We sometimes (eg when user logs out while requests are being made) need to abort fetch requests. This PR adds possibility to use abort signal (returned by AbortController), so it can be handled without hacks.