### PR TITLE
Subscribe before streaming setup

### DIFF
--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -239,7 +239,7 @@ describe('openapi StreamingSubscription', () => {
         });
 
         describe('accepts shouldSubscribeBeforeStreamingSetup boolean flag', () => {
-            it.only('should subscribe when the connection is unavailable and flag is true', () => {
+            it('should subscribe when the connection is unavailable and flag is true', () => {
                 const subscription = new Subscription(
                     '123',
                     transport,

--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -237,6 +237,36 @@ describe('openapi StreamingSubscription', () => {
                 });
             });
         });
+
+        describe('accepts shouldSubscribeBeforeStreamingSetup boolean flag', () => {
+            it.only('should subscribe when the connection is unavailable and flag is true', () => {
+                const subscription = new Subscription(
+                    '123',
+                    transport,
+                    'servicePath',
+                    'src/test/resource',
+                    {},
+                    null,
+                    { shouldSubscribeBeforeStreamingSetup: true },
+                );
+                subscription.onConnectionUnavailable();
+                subscription.onSubscribe();
+
+                expect(transport.post.mock.calls.length).toEqual(1);
+                expect(transport.post.mock.calls[0]).toEqual([
+                    'servicePath',
+                    'src/test/resource',
+                    null,
+                    {
+                        body: {
+                            RefreshRate: 1000,
+                            ContextId: '123',
+                            ReferenceId: '1',
+                        },
+                    },
+                ]);
+            });
+        });
     });
 
     describe('initial snapshot', () => {

--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -237,36 +237,6 @@ describe('openapi StreamingSubscription', () => {
                 });
             });
         });
-
-        describe('accepts shouldSubscribeBeforeStreamingSetup boolean flag', () => {
-            it('should subscribe when the connection is unavailable and flag is true', () => {
-                const subscription = new Subscription(
-                    '123',
-                    transport,
-                    'servicePath',
-                    'src/test/resource',
-                    {},
-                    null,
-                    { shouldSubscribeBeforeStreamingSetup: true },
-                );
-                subscription.onConnectionUnavailable();
-                subscription.onSubscribe();
-
-                expect(transport.post.mock.calls.length).toEqual(1);
-                expect(transport.post.mock.calls[0]).toEqual([
-                    'servicePath',
-                    'src/test/resource',
-                    null,
-                    {
-                        body: {
-                            RefreshRate: 1000,
-                            ContextId: '123',
-                            ReferenceId: '1',
-                        },
-                    },
-                ]);
-            });
-        });
     });
 
     describe('initial snapshot', () => {

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -856,18 +856,18 @@ class Subscription {
         this.onReadyToPerformNextAction();
     }
 
-    /**
-     * Resets the subscription activity
-     */
-    private onActivity() {
-        this.latestActivity = new Date().getTime();
-    }
-
     private setState(state: SubscriptionState) {
         this.currentState = state;
         for (let i = 0; i < this.onStateChangedCallbacks.length; i++) {
             this.onStateChangedCallbacks[i](state);
         }
+    }
+
+    /**
+     * Resets the subscription activity
+     */
+    onActivity() {
+        this.latestActivity = new Date().getTime();
     }
 
     /**

--- a/src/openapi/streaming/types.ts
+++ b/src/openapi/streaming/types.ts
@@ -113,4 +113,8 @@ export interface StreamingConfigurableOptions {
      * If true we wll get streaming heartbeat messages for websocket connection
      */
     isWebsocketStreamingHeartBeatEnabled?: boolean;
+    /**
+     *  Flag to control whether we should subscribe before streaming setup during initial subscribe
+     */
+    shouldSubscribeBeforeStreamingSetup?: boolean;
 }


### PR DESCRIPTION
- As of now we queue subscription requests waiting for streaming and only when streaming setup is done we allow it to subscribe.
- setting up streaming connection takes time because of which our subscription also have to wait for it.
- this PR adds an option to pass a Boolean flag **shouldSubscribeBeforeStreamingSetup** while creating a new subscription. 
- when this flag is passed true we will not wait for streaming connection to setup and will subscribe right away. by doing this we can get the initial snapshot response which we can use to render our UI as early as possible.
- later updates will be passed via the streaming channel when its ready
