### PR TITLE
websocket transport streaming heartbeat added

### DIFF
--- a/src/openapi/streaming/connection/connection.ts
+++ b/src/openapi/streaming/connection/connection.ts
@@ -200,16 +200,7 @@ class Connection {
             return this.createTransport(baseUrl);
         }
 
-        let options;
-        if (this.options && this.options.isWebsocketStreamingHeartBeatEnabled) {
-            if (SelectedTransport.name === 'WebsocketTransport') {
-                options = {
-                    isWebsocketStreamingHeartBeatEnabled: true,
-                };
-            }
-        }
-
-        return new SelectedTransport(baseUrl, this.onTransportFail, options);
+        return new SelectedTransport(baseUrl, this.onTransportFail);
     }
 
     private getSupportedTransports(

--- a/src/openapi/streaming/connection/connection.ts
+++ b/src/openapi/streaming/connection/connection.ts
@@ -200,7 +200,16 @@ class Connection {
             return this.createTransport(baseUrl);
         }
 
-        return new SelectedTransport(baseUrl, this.onTransportFail);
+        let options;
+        if (this.options && this.options.isWebsocketStreamingHeartBeatEnabled) {
+            if (SelectedTransport.name === 'WebsocketTransport') {
+                options = {
+                    isWebsocketStreamingHeartBeatEnabled: true,
+                };
+            }
+        }
+
+        return new SelectedTransport(baseUrl, this.onTransportFail, options);
     }
 
     private getSupportedTransports(

--- a/src/openapi/streaming/connection/transport/websocket-transport.spec.ts
+++ b/src/openapi/streaming/connection/transport/websocket-transport.spec.ts
@@ -499,48 +499,56 @@ describe('openapi WebSocket Transport', () => {
         });
     });
 
-    describe('websocket inactivity finder', (done) => {
-        it('start and stop should work correctly', () => {
-            const transport = new WebSocketTransport(BASE_URL, undefined, {
-                isWebsocketStreamingHeartBeatEnabled: true,
-            });
+    describe('websocket inactivity finder', () => {
+        it('start and stop should work correctly', (done) => {
+            const transport = new WebSocketTransport(BASE_URL, undefined);
             transport.updateQuery(AUTH_TOKEN, CONTEXT_ID);
-            transport.start({}, () => {});
+            transport.start({ isWebsocketStreamingHeartBeatEnabled: true });
             fetchMock.resolve(200, {});
 
-            transport.authorizePromise.then(() => {
+            transport.authorizePromise?.then(() => {
                 // on ws open should start
+                // @ts-expect-error its a readonly property
                 transport.socket.readyState = 1; // WebSocket internal state equal open
+                // @ts-ignore referring to socket method instead of WebSocketTransport
                 transport.socket.onopen();
 
-                expect(transport.inactivityFinderEnabled).toBe(true);
-                expect(
-                    transport.inactivityFinderNextUpdateTimeoutId,
-                ).to.not.equal(null);
+                expect(transport.inactivityFinderRunning).toBe(true);
+                expect(transport.inactivityFinderNextUpdateTimeoutId).not.toBe(
+                    null,
+                );
 
                 // on ws close should stop
+                // @ts-expect-error its a readonly property
                 transport.socket.readyState = 3; // WebSocket internal state equal closed
+                // @ts-expect-error
                 transport.socket.onclose({ code: 1001 });
 
-                expect(transport.inactivityFinderEnabled).toBe(null);
-                expect(transport.inactivityFinderNextUpdateTimeoutId).to.equal(
+                expect(transport.inactivityFinderRunning).toBe(false);
+                expect(transport.inactivityFinderNextUpdateTimeoutId).toBe(
                     null,
                 );
                 done();
             });
         });
 
-        it('should reconnect if connection is established and there is no messages for more than 2.5 seconds', (done) => {
-            const transport = new WebSocketTransport(BASE_URL, undefined, {
+        it('should reconnect if connection is established and there is no message since 3 seconds', (done) => {
+            const stateChangedSpy: jest.Mock = jest
+                .fn()
+                .mockName('stateChanged');
+            const transport = new WebSocketTransport(BASE_URL, undefined);
+            transport.setStateChangedCallback(stateChangedSpy);
+            transport.updateQuery(AUTH_TOKEN, CONTEXT_ID);
+            transport.start({
                 isWebsocketStreamingHeartBeatEnabled: true,
             });
-            transport.updateQuery(AUTH_TOKEN, CONTEXT_ID);
-            transport.start({}, () => {});
             fetchMock.resolve(200, {});
 
-            transport.authorizePromise.then(() => {
+            transport.authorizePromise?.then(() => {
                 expect(global.WebSocket).toBeCalledTimes(1);
+                // @ts-expect-error its a readonly property
                 transport.socket.readyState = 1;
+                // @ts-ignore referring to socket method instead of WebSocketTransport
                 transport.socket.onopen();
 
                 const dataBuffer = new window.TextEncoder().encode(
@@ -554,10 +562,14 @@ describe('openapi WebSocket Transport', () => {
                     0,
                 );
                 payload.set(dataBuffer, 17);
-                transport.socket.onmessage({ data: payload.buffer });
-
-                tick(6000);
-                expect(global.WebSocket).toBeCalledTimes(2);
+                transport.socket?.onmessage?.({ data: payload.buffer } as any);
+                expect(stateChangedSpy.mock.calls[1]).toEqual([
+                    constants.CONNECTION_STATE_CONNECTED,
+                ]);
+                tick(3001);
+                expect(stateChangedSpy.mock.calls[2]).toEqual([
+                    constants.CONNECTION_STATE_RECONNECTING,
+                ]);
 
                 done();
             });

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -193,6 +193,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             connectRetryDelayLevels,
             parserEngines,
             parsers,
+            isWebsocketStreamingHeartBeatEnabled,
         } = options;
 
         this.connectionOptions = {
@@ -203,6 +204,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             // Streaming service relays message payload received from publishers as it is, which could be protobuf encoded.
             // This protocol is used to serialize the message envelope rather than the payload
             messageSerializationProtocol,
+            isWebsocketStreamingHeartBeatEnabled,
         };
 
         if (typeof connectRetryDelay === 'number') {

--- a/src/openapi/streaming/types.ts
+++ b/src/openapi/streaming/types.ts
@@ -16,6 +16,7 @@ export interface ConnectionOptions {
     waitForPageLoad?: boolean;
     transport?: Array<TransportTypes>;
     messageSerializationProtocol?: IHubProtocol;
+    isWebsocketStreamingHeartBeatEnabled?: boolean;
 }
 
 export type ConnectionState =
@@ -107,4 +108,8 @@ export interface StreamingConfigurableOptions {
      */
     messageProtocol?: Record<string, any>;
     messageSerializationProtocol?: IHubProtocol;
+    /**
+     * If true we wll get streaming heartbeat messages for websocket connection
+     */
+    isWebsocketStreamingHeartBeatEnabled?: boolean;
 }


### PR DESCRIPTION
- Due to the fact that browsers may disconnect web-socket connection without knowing so, we need to add a heartbeat protocol on top of web-socket in the web-socket streaming service.

- To enable heartbeats on a connection (or reconnection) the following query parameter must be added to the connection URL: **&sendHeartbeats=true**

- The heartbeat messages follow the usual control message format, so they come with the reference id **_connectionheartbeat**

-  So by sending the "sendHeartbeats=true" as queryParam a connection heartbeat is sent after 2 seconds of inactivity on a streaming connection, i.e. when there has been no heartbeat or other streaming message for 2 seconds

- In this change we try to reconnect the web socket if we don't receive any message on the web socket for 2.5 seconds and we are not waiting for authorization with new token
