### PR TITLE
Enhanced getActualDecimals function 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### v10.0.1
+- Enhanced getActualDecimals function to support large numbers.
+
+
 ### v10.0.0
 
 #### Breaking

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.0.0",
+    "version": "10.0.1",
     "engines": {
         "node": ">=14"
     },

--- a/src/number-formatting/format.spec.ts
+++ b/src/number-formatting/format.spec.ts
@@ -56,6 +56,18 @@ describe('NumberFormatting format', () => {
             expect(formatNumberNoRounding(-1.1, 4, 5)).toEqual('-1.1000');
             expect(formatNumberNoRounding(-5e-7, 4, 8)).toEqual('-0.0000005');
         });
+
+        it('handles large numeric value', () => {
+            expect(formatNumberNoRounding(92893282191.78, 2)).toEqual(
+                '92,893,282,191.78',
+            );
+            expect(formatNumberNoRounding(12345678912345.6, 4)).toEqual(
+                '12,345,678,912,345.6000',
+            );
+            expect(formatNumberNoRounding(12345678912.3456, 1, 3)).toEqual(
+                '12,345,678,912.346',
+            );
+        });
         it('handles numeric strings', () => {
             expect(formatNumberNoRounding('1.1', 4)).toEqual('1.1000');
             expect(formatNumberNoRounding('1.1212', 1)).toEqual('1.1212');

--- a/src/number-formatting/index.ts
+++ b/src/number-formatting/index.ts
@@ -155,7 +155,7 @@ class NumberFormatting implements NumberFormattingOptions {
 
         return (number - Math.floor(number))
             .toFixed(maxDecimals)
-            .substring(2, 10)
+            .substring(2, 2 + maxDecimals)
             .replace(numberOfZerosRx, '').length;
     }
 }

--- a/src/number-formatting/index.ts
+++ b/src/number-formatting/index.ts
@@ -148,6 +148,7 @@ class NumberFormatting implements NumberFormattingOptions {
     /**
      * Returns the actual number of decimals that a number has.
      * @param number - number or numeric string
+     * @param isNoRounding - oprional or boolean
      */
     getActualDecimals(number: number, isNoRounding?: boolean) {
         number = Math.abs(number);
@@ -169,7 +170,7 @@ class NumberFormatting implements NumberFormattingOptions {
                 .length;
         }
 
-        const decimal = number.toString().split('.')[1];
+        const decimal = sNumber.split('.')[1];
         const decimalLength = decimal ? decimal.length : 0;
         return Math.min(decimalLength, 8);
     }

--- a/src/number-formatting/index.ts
+++ b/src/number-formatting/index.ts
@@ -5,7 +5,15 @@ import shortFormat from './short-format';
 
 const numberOfZerosRx = /0+$/;
 
-// browsers [ie,chromium,firefox] start rounding of decimal number after 16-17 chars.
+/**
+ * Come up with this number through experimentation.
+ * In js if the number is greater than 16/17 chars then it starts to round off
+ * @example
+ * let c = 123456789123456789 , c becomes 123456789123456780
+ * 123456789123456.789 becomes 123456789123456.78
+ * 1234567891234567.1 becomes 1234567891234567
+ * 1234567891234567.8 becomes 1234567891234567.8
+ **/
 const maxChars = 16;
 
 export type NumberOptions = Readonly<{

--- a/src/number-formatting/index.ts
+++ b/src/number-formatting/index.ts
@@ -160,7 +160,6 @@ class NumberFormatting implements NumberFormattingOptions {
         }
 
         // used by formatNoRounding
-        // using toFixed will not give exact decimal values for large numbers + it does rounding
         const sNumber = number.toString();
         if (sNumber.match(expoenetialRx)) {
             // handled case where sNumber still has exponential notation in case of negative power


### PR DESCRIPTION
Why?
`formatNoRounding` function is appending 0 values(uptil 8 decimal) for large numbers. 
- Reason - `getActualDecimals`  is returning incorrect decimal length due to `number-Math.float(number)`  and `toFixed` which  approximate value due to floating precision 
- In case of  `formatNoRounding(92893282191.78,2)`, getActualDecimal will return the decimal part `"0.77999878"` as toFixed(8) is not able to roundoff (Thus length 8) and we get `'92893282191.78000000'` which is wrong.

Soln
- Will adjust constant 8 that is passed to `toFixed`.
- Browser start rounding off(precision) decimal number after 16-17 chars. So by subtracting const 16(taking assumption) with non-decimal places of number we can get the actual decimal place where the browser is able to round off correctly.

