### PR TITLE
Fix circlular log message

### DIFF
--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -744,11 +744,11 @@ class Streaming extends MicroEmitter<EmittedEvents> {
      * @param subscription - subscription
      */
     private onOrphanFound(subscription: Subscription) {
-        log.info(
-            LOG_AREA,
-            'Subscription has become orphaned - resetting',
-            subscription,
-        );
+        log.info(LOG_AREA, 'Subscription has become orphaned - resetting', {
+            referenceId: subscription.referenceId,
+            streamingContextId: subscription.streamingContextId,
+            servicePath: subscription.servicePath,
+        });
         this.connection.onOrphanFound();
         subscription.reset();
     }


### PR DESCRIPTION
by passing the whole subscription, when we do JSON stringify, it can hit a circular reference.