### PR TITLE
Log received message count on disconnect

### DIFF
--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -404,7 +404,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             case this.CONNECTION_STATE_DISCONNECTED:
                 log.info(
                     LOG_AREA,
-                    'Connection is disconnected',
+                    'Connection disconnected',
                     { contextMessageCount: this.contextMessageCount },
                     { persist: true },
                 );
@@ -428,7 +428,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             case this.CONNECTION_STATE_RECONNECTING:
                 log.info(
                     LOG_AREA,
-                    'Connection is reconnecting',
+                    'Connection disconnected. Reconnecting...',
                     { contextMessageCount: this.contextMessageCount },
                     { persist: true },
                 );


### PR DESCRIPTION
Adding this so we can compare with the streaming gateway's logs which look like this:

```
Abort called on Session. Sent messages: 20496. Received messages: 20495
```

This PR needs further work. @jdhodges