### PR TITLE
streaming heartbeat query param on create of ws

### DIFF
--- a/src/openapi/streaming/connection/transport/websocket-transport.ts
+++ b/src/openapi/streaming/connection/transport/websocket-transport.ts
@@ -290,9 +290,13 @@ class WebsocketTransport implements StreamingTransportInterface {
 
     private createSocket() {
         try {
-            const url = this.normalizeWebSocketUrl(
+            let url = this.normalizeWebSocketUrl(
                 `${this.connectionUrl}${this.query}`,
             );
+
+            if (this.isWebsocketStreamingHeartBeatEnabled) {
+                url += '&sendHeartbeats=true';
+            }
 
             log.debug(LOG_AREA, 'Creating WebSocket connection', { url });
             const socket = new WebSocket(url);
@@ -595,9 +599,7 @@ class WebsocketTransport implements StreamingTransportInterface {
         let query = `?contextId=${encodeURIComponent(
             contextId,
         )}&Authorization=${encodeURIComponent(authToken)}`;
-        if (this.isWebsocketStreamingHeartBeatEnabled) {
-            query += '&sendHeartbeats=true';
-        }
+
         if (this.lastMessageId != null) {
             query += `&messageid=${this.lastMessageId}`;
         }


### PR DESCRIPTION
this is the continuation of this pr: https://github.com/SaxoBank/openapi-clientlib-js/pull/416

earlier we are passing the sendHeartbeats query param in the update query method which get invoked when we reconnect or some failure happens but it doesn't add sendHeartbeats on initial ws socket creation for success case.

so moving the logic to create ws function which gets invoked in call cases.
