### PR TITLE
websocket - Last message id fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### v10.2.7
+- Do not warn on messages out of order on reconnections
+- make sure the last message id is passed on reconnect
+
 ### v10.2.6
 - Fixes to websocket streaming transport heartbeat to send the parameter on the initial connection
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "10.2.5",
+  "version": "10.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.2.6",
+    "version": "10.2.7",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/streaming/connection/transport/signalr-core-transport.ts
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.ts
@@ -513,6 +513,10 @@ class SignalrCoreTransport implements StreamingTransportInterface {
             forceAuth,
         });
 
+        if (contextId !== this.contextId) {
+            this.lastMessageId = null;
+        }
+
         this.contextId = contextId;
         this.authExpiry = authExpiry;
         this.authToken = authToken.replace('BEARER ', '');

--- a/src/openapi/streaming/connection/transport/websocket-transport.ts
+++ b/src/openapi/streaming/connection/transport/websocket-transport.ts
@@ -22,7 +22,11 @@ import type {
     StateChangeCallback,
     ReceiveCallback,
 } from '../types';
-import { OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS } from '../../control-messages';
+import {
+    OPENAPI_CONTROL_MESSAGE_DISCONNECT,
+    OPENAPI_CONTROL_MESSAGE_RECONNECT,
+    OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS,
+} from '../../control-messages';
 
 const LOG_AREA = 'PlainWebSocketsTransport';
 
@@ -191,11 +195,15 @@ class WebsocketTransport implements StreamingTransportInterface {
 
             const messageId = uint64utils.uint64ToNumber(messageIdBuffer);
             if (this.lastMessageId && messageId !== this.lastMessageId + 1) {
+                const firstReferenceId = data[0]?.ReferenceId;
                 if (
                     messageId === 1 &&
-                    data[0]?.ReferenceId ===
+                    ((firstReferenceId ===
                         OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS &&
-                    !data[0].TargetReferenceIds?.length
+                        !data[0].TargetReferenceIds?.length) ||
+                        firstReferenceId ===
+                            OPENAPI_CONTROL_MESSAGE_RECONNECT ||
+                        firstReferenceId === OPENAPI_CONTROL_MESSAGE_DISCONNECT)
                 ) {
                     log.info(LOG_AREA, 'Message id reset to 1', {
                         messageId,

--- a/src/openapi/streaming/control-messages.ts
+++ b/src/openapi/streaming/control-messages.ts
@@ -1,0 +1,6 @@
+export const OPENAPI_CONTROL_MESSAGE_PREFIX = '_';
+export const OPENAPI_CONTROL_MESSAGE_HEARTBEAT = '_heartbeat';
+export const OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS =
+    '_resetsubscriptions';
+export const OPENAPI_CONTROL_MESSAGE_RECONNECT = '_reconnect';
+export const OPENAPI_CONTROL_MESSAGE_DISCONNECT = '_disconnect';

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -11,13 +11,13 @@ import * as streamingTransports from './connection/transportTypes';
 import type * as types from './types';
 import type AuthProvider from '../authProvider';
 import type { ITransport } from '../transport/transport-base';
-
-export const OPENAPI_CONTROL_MESSAGE_PREFIX = '_';
-export const OPENAPI_CONTROL_MESSAGE_HEARTBEAT = '_heartbeat';
-export const OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS =
-    '_resetsubscriptions';
-export const OPENAPI_CONTROL_MESSAGE_RECONNECT = '_reconnect';
-export const OPENAPI_CONTROL_MESSAGE_DISCONNECT = '_disconnect';
+import {
+    OPENAPI_CONTROL_MESSAGE_PREFIX,
+    OPENAPI_CONTROL_MESSAGE_DISCONNECT,
+    OPENAPI_CONTROL_MESSAGE_HEARTBEAT,
+    OPENAPI_CONTROL_MESSAGE_RECONNECT,
+    OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS,
+} from './control-messages';
 
 const DEFAULT_CONNECT_RETRY_DELAY = 1000;
 

--- a/src/openapi/streaming/types.ts
+++ b/src/openapi/streaming/types.ts
@@ -5,7 +5,7 @@ import type {
     OPENAPI_CONTROL_MESSAGE_HEARTBEAT,
     OPENAPI_CONTROL_MESSAGE_RECONNECT,
     OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS,
-} from './streaming';
+} from './control-messages';
 import type { TRANSPORT_NAME_MAP } from './connection/connection';
 import type * as connectionConstants from './connection/constants';
 import type { StreamingData } from './connection/types';

--- a/src/openapi/streaming/types.ts
+++ b/src/openapi/streaming/types.ts
@@ -38,13 +38,14 @@ export interface StreamingMessage<T = unknown, R = string> {
     ReservedField?: number;
     DataFormat?: DataFormat;
     Data: T;
-}
-
-interface StreamingControlMessage<T = StreamingData, R = string>
-    extends StreamingMessage<T, R> {
     Heartbeats?: Heartbeats[];
     TargetReferenceIds?: string[];
 }
+
+type StreamingControlMessage<T = StreamingData, R = string> = StreamingMessage<
+    T,
+    R
+>;
 
 export type HeartbeatsControlMessage = StreamingControlMessage<
     {


### PR DESCRIPTION
1. do not log a error when it is a normal situation (reconnecting without last message id failed)
2. make sure when reconnecting we use a last message id (extra call to update query)
3. If the context changes we cannot re-use the last message id, so clear it