### PR TITLE
Convert HTTP method names passed to fetch to uppercase

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v10.2.8
+- Convert HTTP method names passed to fetch to uppercase (see: https://bugs.chromium.org/p/chromium/issues/detail?id=1228178)
+
 ### v10.2.7
 - Do not warn on messages out of order on reconnections
 - make sure the last message id is passed on reconnect

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "10.2.7",
+  "version": "10.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.2.7",
+    "version": "10.2.8",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/authProvider.spec.ts
+++ b/src/openapi/authProvider.spec.ts
@@ -331,7 +331,7 @@ describe('openapi AuthProvider', () => {
             expect(fetch).toBeCalledTimes(1);
             expect(fetch.mock.calls[0]).toEqual([
                 'http://refresh',
-                expect.objectContaining({ method: 'post' }),
+                expect.objectContaining({ method: 'POST' }),
             ]);
         });
 
@@ -350,7 +350,7 @@ describe('openapi AuthProvider', () => {
             expect(authProvider.getExpiry()).toEqual(initialOptions.expiry);
 
             expect(fetch.mock.calls[0][0]).toEqual('http://refresh');
-            expect(fetch.mock.calls[0][1]?.method).toEqual('post');
+            expect(fetch.mock.calls[0][1]?.method).toEqual('POST');
 
             fetch.resolve(200, { token: 'TOK2', expiry: 60 });
             setTimeout(function () {

--- a/src/openapi/transport/core.spec.ts
+++ b/src/openapi/transport/core.spec.ts
@@ -289,7 +289,7 @@ describe('openapi TransportCore', () => {
                 'localhost/openapi/service_path/account/info/te/st',
                 {
                     body: undefined,
-                    method: 'get',
+                    method: 'GET',
                     headers: { 'X-Request-Id': expect.any(String) },
                     // credentials: 'include' adds cookies.
                     // Cookies used by some open api operations. if we don't default here make sure it is sent through with subscription requests.
@@ -312,7 +312,7 @@ describe('openapi TransportCore', () => {
                 'localhost/openapi/service_path/account/info/te/st',
                 {
                     body: '{"Test":true}',
-                    method: 'post',
+                    method: 'POST',
                     headers: {
                         'Content-Type': 'application/json; charset=UTF-8',
                         'X-Request-Id': expect.any(String),
@@ -338,7 +338,7 @@ describe('openapi TransportCore', () => {
                 'localhost/openapi/service_path/account/info/te/st',
                 {
                     body: '{"Test":true}',
-                    method: 'post',
+                    method: 'POST',
                     headers: { 'X-Request-Id': expect.any(String) },
                     credentials: 'include',
                 },
@@ -366,7 +366,7 @@ describe('openapi TransportCore', () => {
                 'localhost/openapi/platform/v1/media/fleeb',
                 {
                     body: expect.any(window.FormData),
-                    method: 'post',
+                    method: 'POST',
                     headers: { 'X-Request-Id': expect.any(String) },
                     credentials: 'include',
                 },
@@ -392,7 +392,7 @@ describe('openapi TransportCore', () => {
                 'localhost/openapi/platform/v1/media/fleeb',
                 {
                     body: expect.any(window.Blob),
-                    method: 'post',
+                    method: 'POST',
                     headers: { 'X-Request-Id': expect.any(String) },
                     credentials: 'include',
                 },
@@ -417,7 +417,7 @@ describe('openapi TransportCore', () => {
                 'localhost/openapi/platform/v1/media/fleeb',
                 {
                     body: expect.any(window.URLSearchParams),
-                    method: 'post',
+                    method: 'POST',
                     headers: { 'X-Request-Id': expect.any(String) },
                     credentials: 'include',
                 },
@@ -778,7 +778,7 @@ describe('openapi TransportCore', () => {
             expect(fetch.mock.calls[0]).toEqual([
                 expect.anything(),
                 expect.objectContaining({
-                    method: 'get',
+                    method: 'GET',
                     headers: { 'X-Request-Id': expect.any(String) },
                 }),
             ]);
@@ -789,9 +789,9 @@ describe('openapi TransportCore', () => {
             expect(fetch.mock.calls[0]).toEqual([
                 expect.anything(),
                 expect.objectContaining({
-                    method: 'post',
+                    method: 'POST',
                     headers: {
-                        'X-HTTP-Method-Override': 'put',
+                        'X-HTTP-Method-Override': 'PUT',
                         'X-Request-Id': expect.any(String),
                     },
                 }),
@@ -803,7 +803,7 @@ describe('openapi TransportCore', () => {
             expect(fetch.mock.calls[0]).toEqual([
                 expect.anything(),
                 expect.objectContaining({
-                    method: 'post',
+                    method: 'POST',
                     headers: { 'X-Request-Id': expect.any(String) },
                 }),
             ]);
@@ -814,9 +814,9 @@ describe('openapi TransportCore', () => {
             expect(fetch.mock.calls[0]).toEqual([
                 expect.anything(),
                 expect.objectContaining({
-                    method: 'post',
+                    method: 'POST',
                     headers: {
-                        'X-HTTP-Method-Override': 'delete',
+                        'X-HTTP-Method-Override': 'DELETE',
                         'X-Request-Id': expect.any(String),
                     },
                 }),
@@ -831,7 +831,7 @@ describe('openapi TransportCore', () => {
                     body: '{}',
                     headers: {
                         'Content-Type': 'application/json; charset=UTF-8',
-                        'X-HTTP-Method-Override': 'patch',
+                        'X-HTTP-Method-Override': 'PATCH',
                         'X-Request-Id': expect.any(String),
                     },
                 }),
@@ -855,7 +855,7 @@ describe('openapi TransportCore', () => {
             expect(fetch.mock.calls[0]).toEqual([
                 expect.anything(),
                 expect.objectContaining({
-                    method: 'patch',
+                    method: 'PATCH',
                     body: '{"exampleField":"test"}',
                     headers: {
                         'Content-Type': 'application/json; charset=UTF-8',

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -204,10 +204,10 @@ export function convertFetchSuccess(
     return convertedPromise;
 }
 
-function getBody(method: HTTPMethodType, options?: Options): any {
+function getBody(method: Uppercase<HTTPMethodType>, options?: Options): any {
     // If PATCH without body occurs, create empty payload.
     // Reason: Some proxies and default configs for CDNs like Akamai have issues with accepting PATCH with content-length: 0.
-    if (method === 'patch' && !options?.body) {
+    if (method === 'PATCH' && !options?.body) {
         return {};
     }
 
@@ -228,7 +228,7 @@ function localFetch<Response = any>(
     url: string,
     options?: Options,
 ): Promise<OAPIRequestResult<Response>> {
-    let method = httMethod.toLowerCase() as HTTPMethodType;
+    let method = httMethod.toUpperCase() as Uppercase<HTTPMethodType>;
     let body = getBody(method, options);
     const headers = options?.headers || {};
     const cache = options?.cache;
@@ -244,14 +244,14 @@ function localFetch<Response = any>(
 
     if (
         useXHttpMethodOverride &&
-        (method === 'put' || method === 'delete' || method === 'patch')
+        (method === 'PUT' || method === 'DELETE' || method === 'PATCH')
     ) {
         headers['X-HTTP-Method-Override'] = method;
-        method = 'post';
+        method = 'POST';
     }
 
     if (cache === false) {
-        if (method === 'get') {
+        if (method === 'GET') {
             const cacheBreak = String(cacheBreakNum++);
             url += (url.indexOf('?') > 0 ? '&_=' : '?_=') + cacheBreak;
         }


### PR DESCRIPTION
This PR makes an http method name passed to fetch uppercase.

 See https://bugs.chromium.org/p/chromium/issues/detail?id=1228178