### PR TITLE
Add subscription modify option to use ReplaceReferenceId

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v10.3.0
+- Add new `isReplace` option for more efficient subscription modifications when an endpoint doesn't support `PATCH`.
+
 ### v10.2.9
 - Add shouldSubscribeBeforeStreamingSetup option. New options enables subscribe before streaming setup.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "10.2.9",
+  "version": "10.3.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "10.3.0-beta.0",
+  "version": "10.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.2.9",
+    "version": "10.3.0-beta.0",
     "engines": {
         "node": ">=14"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.3.0-beta.0",
+    "version": "10.3.0",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/streaming/streaming-websocket.spec.ts
+++ b/src/openapi/streaming/streaming-websocket.spec.ts
@@ -813,7 +813,11 @@ describe('openapi Streaming', () => {
             streaming.subscriptions.push(subscription);
 
             const args = {};
-            const options = { isPatch: false, patchArgsDelta: {} };
+            const options = {
+                isPatch: false,
+                isReplace: false,
+                patchArgsDelta: {},
+            };
             streaming.modify(subscription, args, options);
 
             expect(subscription.onModify.mock.calls.length).toEqual(1);

--- a/src/openapi/streaming/streaming.spec.ts
+++ b/src/openapi/streaming/streaming.spec.ts
@@ -1184,7 +1184,11 @@ describe('openapi Streaming', () => {
             streaming.subscriptions.push(subscription);
 
             const args = {};
-            const options = { isPatch: false, isReplace: false, patchArgsDelta: {} };
+            const options = {
+                isPatch: false,
+                isReplace: false,
+                patchArgsDelta: {},
+            };
             streaming.modify(subscription, args, options);
 
             expect(subscription.onModify.mock.calls.length).toEqual(1);

--- a/src/openapi/streaming/streaming.spec.ts
+++ b/src/openapi/streaming/streaming.spec.ts
@@ -1184,7 +1184,7 @@ describe('openapi Streaming', () => {
             streaming.subscriptions.push(subscription);
 
             const args = {};
-            const options = { isPatch: false, patchArgsDelta: {} };
+            const options = { isPatch: false, isReplace: false, patchArgsDelta: {} };
             streaming.modify(subscription, args, options);
 
             expect(subscription.onModify.mock.calls.length).toEqual(1);

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -1120,7 +1120,11 @@ class Streaming extends MicroEmitter<EmittedEvents> {
     modify(
         subscription: Subscription,
         args: Record<string, unknown>,
-        options: { isPatch: boolean; patchArgsDelta: Record<string, unknown> },
+        options: {
+            isPatch: boolean;
+            isReplace: boolean;
+            patchArgsDelta: Record<string, unknown>;
+        },
     ) {
         subscription.onModify(args, options);
     }

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import MicroEmitter from '../../micro-emitter';
 import log from '../../log';
 import { padLeft } from '../../utils/string';

--- a/src/openapi/streaming/subscription-actions.ts
+++ b/src/openapi/streaming/subscription-actions.ts
@@ -2,11 +2,13 @@ export const ACTION_SUBSCRIBE = 0x1 as const;
 export const ACTION_UNSUBSCRIBE = 0x2 as const;
 export const ACTION_MODIFY = 0x4 as const;
 export const ACTION_MODIFY_PATCH = 0x8 as const;
-export const ACTION_UNSUBSCRIBE_BY_TAG_PENDING = 0x10 as const;
+export const ACTION_MODIFY_REPLACE = 0x10 as const;
+export const ACTION_UNSUBSCRIBE_BY_TAG_PENDING = 0x12 as const;
 
 export type SubscriptionAction =
     | typeof ACTION_SUBSCRIBE
     | typeof ACTION_UNSUBSCRIBE
     | typeof ACTION_MODIFY
     | typeof ACTION_MODIFY_PATCH
+    | typeof ACTION_MODIFY_REPLACE
     | typeof ACTION_UNSUBSCRIBE_BY_TAG_PENDING;

--- a/src/openapi/streaming/subscription-actions.ts
+++ b/src/openapi/streaming/subscription-actions.ts
@@ -3,7 +3,7 @@ export const ACTION_UNSUBSCRIBE = 0x2 as const;
 export const ACTION_MODIFY = 0x4 as const;
 export const ACTION_MODIFY_PATCH = 0x8 as const;
 export const ACTION_MODIFY_REPLACE = 0x10 as const;
-export const ACTION_UNSUBSCRIBE_BY_TAG_PENDING = 0x12 as const;
+export const ACTION_UNSUBSCRIBE_BY_TAG_PENDING = 0x20 as const;
 
 export type SubscriptionAction =
     | typeof ACTION_SUBSCRIBE

--- a/src/openapi/streaming/subscription-queue.spec.ts
+++ b/src/openapi/streaming/subscription-queue.spec.ts
@@ -169,7 +169,7 @@ describe('openapi SubscriptionQueue', () => {
                 ],
             ],
             [
-                'should clear patches if doing a subscribe and calling clearPatches',
+                'should clear patches if doing a subscribe and calling clearModifys',
                 [
                     // See above but in this case we call clear Patches when subscribing
                     subscribe(),
@@ -179,7 +179,7 @@ describe('openapi SubscriptionQueue', () => {
                     unsubscribe(),
                     subscribe(),
                 ],
-                [subscribe(), 'clearPatches'],
+                [subscribe(), 'clearModifys'],
             ],
             [
                 'should clear patches if doing a unsubscribe even if we have a modify on a unsubscribe',
@@ -210,7 +210,7 @@ describe('openapi SubscriptionQueue', () => {
                     subscribe(),
                     modifyPatch(),
                 ],
-                [unsubscribe(), modifyPatch(), subscribe(), 'clearPatches'],
+                [unsubscribe(), modifyPatch(), subscribe(), 'clearModifys'],
             ],
             [
                 'should drop all actions except unsubscribe force followed by subscribe',
@@ -254,7 +254,7 @@ describe('openapi SubscriptionQueue', () => {
                     subscribe(),
                     modifyPatch(),
                 ],
-                [forceUnsubscribe(), subscribe(), 'clearPatches'],
+                [forceUnsubscribe(), subscribe(), 'clearModifys'],
             ],
 
             // tag tests
@@ -283,8 +283,8 @@ describe('openapi SubscriptionQueue', () => {
                 queue.enqueue(action);
             }
             for (const action of expectedActions) {
-                if (action === 'clearPatches') {
-                    queue.clearPatches();
+                if (action === 'clearModifys') {
+                    queue.clearModifys();
                 } else {
                     expect(queue.dequeue()).toStrictEqual(action);
                 }

--- a/src/openapi/streaming/subscription-queue.spec.ts
+++ b/src/openapi/streaming/subscription-queue.spec.ts
@@ -58,6 +58,10 @@ describe('openapi SubscriptionQueue', () => {
             return { action: SubscriptionActions.ACTION_MODIFY_PATCH };
         }
 
+        function modifyReplace() {
+            return { action: SubscriptionActions.ACTION_MODIFY_REPLACE };
+        }
+
         function unsubscribeByTagPending() {
             return {
                 action: SubscriptionActions.ACTION_UNSUBSCRIBE_BY_TAG_PENDING,
@@ -255,6 +259,14 @@ describe('openapi SubscriptionQueue', () => {
                     modifyPatch(),
                 ],
                 [forceUnsubscribe(), subscribe(), 'clearModifys'],
+            ],
+
+            // modify-replace
+            [
+                'should discard the earlier of a consecutive pair of modify-replace actions',
+                // unlike with patch, here we send all the arguments, so can do this
+                [modifyReplace(), modifyReplace()],
+                [modifyReplace()],
             ],
 
             // tag tests

--- a/src/openapi/streaming/subscription-queue.ts
+++ b/src/openapi/streaming/subscription-queue.ts
@@ -2,17 +2,14 @@ import {
     ACTION_SUBSCRIBE,
     ACTION_UNSUBSCRIBE,
     ACTION_MODIFY_PATCH,
+    ACTION_MODIFY_REPLACE,
     ACTION_UNSUBSCRIBE_BY_TAG_PENDING,
 } from './subscription-actions';
 import type { SubscriptionAction } from './subscription-actions';
 
 export interface QueuedItem {
     action: SubscriptionAction;
-    args?: {
-        force?: boolean;
-        replace?: boolean;
-        [p: string]: any;
-    };
+    args?: { force?: boolean; [p: string]: any };
 }
 
 /**
@@ -102,23 +99,25 @@ class SubscriptionQueue {
 
     /**
      * This is called at the point of subscribing.
-     * We know at that point we do not need any follow up patches
+     * We know at that point we do not need any follow up modifys
      * or subscribes.
      */
-    clearPatches() {
+    clearModifys() {
         const newItems = [];
-        let reachedNonPatchSubscribe = false;
+        let reachedNonModifySubscribe = false;
         for (let i = 0; i < this.items.length; i++) {
             const action = this.items[i].action;
             if (
-                !reachedNonPatchSubscribe &&
+                !reachedNonModifySubscribe &&
                 action !== ACTION_SUBSCRIBE &&
-                action !== ACTION_MODIFY_PATCH
+                action !== ACTION_MODIFY_PATCH &&
+                action !== ACTION_MODIFY_REPLACE
+                //
             ) {
                 // The unit tests don't hit this and I can't think of a way they would
                 // but I'm keeping it in because I'm not fully confident we can just reset the list
                 newItems.push(this.items[i]);
-                reachedNonPatchSubscribe = true;
+                reachedNonModifySubscribe = true;
             }
         }
         this.items = newItems;

--- a/src/openapi/streaming/subscription-queue.ts
+++ b/src/openapi/streaming/subscription-queue.ts
@@ -10,7 +10,7 @@ export interface QueuedItem {
     action: SubscriptionAction;
     args?: {
         force?: boolean;
-        resubscribe?: boolean;
+        replace?: boolean;
         [p: string]: any;
     };
 }

--- a/src/openapi/streaming/subscription-queue.ts
+++ b/src/openapi/streaming/subscription-queue.ts
@@ -8,7 +8,11 @@ import type { SubscriptionAction } from './subscription-actions';
 
 export interface QueuedItem {
     action: SubscriptionAction;
-    args?: { force?: boolean; [p: string]: any };
+    args?: {
+        force?: boolean;
+        resubscribe?: boolean;
+        [p: string]: any;
+    };
 }
 
 /**

--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -443,7 +443,7 @@ describe('openapi StreamingSubscription', () => {
             const patchArgsDelta = { argsDelta: 'delta' };
             subscription.onModify(
                 { args: 'test' },
-                { isPatch: true, patchArgsDelta },
+                { isPatch: true, isReplace: false, patchArgsDelta },
             );
 
             const streamingData = {
@@ -1501,11 +1501,13 @@ describe('openapi StreamingSubscription', () => {
                     },
                     Object {
                       "action": 1,
-                      "args": undefined,
+                      "args": Object {
+                        "replace": false,
+                      },
                     },
                   ],
                 }
-                `);
+            `);
 
             expect(transport.post.mock.calls.length).toEqual(0);
             expect(transport.delete.mock.calls.length).toEqual(0);
@@ -1580,11 +1582,13 @@ describe('openapi StreamingSubscription', () => {
                     },
                     Object {
                       "action": 1,
-                      "args": undefined,
+                      "args": Object {
+                        "replace": false,
+                      },
                     },
                   ],
                 }
-                `);
+            `);
 
             expect(transport.post.mock.calls.length).toEqual(0);
             expect(transport.delete.mock.calls.length).toEqual(0);
@@ -1772,7 +1776,9 @@ describe('openapi StreamingSubscription', () => {
                       "items": Array [
                         Object {
                           "action": 1,
-                          "args": undefined,
+                          "args": Object {
+                            "replace": false,
+                          },
                         },
                       ],
                     }
@@ -2044,6 +2050,7 @@ describe('openapi StreamingSubscription', () => {
                 const patchArgsDelta = { testArgs: 'argsDelta' };
                 subscription.onModify(newArgs, {
                     isPatch: true,
+                    isReplace: false,
                     patchArgsDelta,
                 });
                 // new arguments assigned to the subscription
@@ -2118,10 +2125,12 @@ describe('openapi StreamingSubscription', () => {
                 const newArgs = { args: 'newArgs' };
                 subscription.onModify(args, {
                     isPatch: true,
+                    isReplace: false,
                     patchArgsDelta: { newArgs: 'firstArgs' },
                 });
                 subscription.onModify(newArgs, {
                     isPatch: true,
+                    isReplace: false,
                     patchArgsDelta: { newArgs: 'secondArgs' },
                 });
 
@@ -2171,7 +2180,7 @@ describe('openapi StreamingSubscription', () => {
 
                 subscription.onModify(
                     { newArgs: 'test' },
-                    { isPatch: true, patchArgsDelta },
+                    { isPatch: true, isReplace: false, patchArgsDelta },
                 );
                 expect(subscription.currentState).toEqual(
                     subscription.STATE_PATCH_REQUESTED,
@@ -2222,7 +2231,7 @@ describe('openapi StreamingSubscription', () => {
 
                 subscription.onModify(
                     { newArgs: 'test' },
-                    { isPatch: true, patchArgsDelta },
+                    { isPatch: true, isReplace: false, patchArgsDelta },
                 );
                 expect(subscription.currentState).toEqual(
                     subscription.STATE_PATCH_REQUESTED,

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -456,6 +456,7 @@ class Subscription {
      * @param queuedAction - queuedAction
      * @param isLastQueuedAction - isLastQueuedAction
      */
+    // eslint-disable-next-line complexity
     private performAction(
         queuedAction: QueuedItem | undefined,
         isLastQueuedAction?: boolean,

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -1023,7 +1023,11 @@ class Subscription {
      */
     onModify(
         newArgs?: Record<string, unknown>,
-        options?: { isPatch: boolean; patchArgsDelta: Record<string, unknown> },
+        options?: {
+            isPatch: boolean;
+            patchArgsDelta: Record<string, unknown>;
+            isReplace: boolean;
+        },
     ) {
         if (this.isDisposed) {
             throw new Error(

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -299,7 +299,7 @@ class Subscription {
     /**
      * Call to actually do a subscribe.
      */
-    private subscribe(replace = false) {
+    private subscribe({ replace = false } = {}) {
         const previousReferenceId = this.referenceId;
 
         // capture the reference id so we can tell in the response whether it is the latest call
@@ -451,9 +451,9 @@ class Subscription {
             case ACTION_SUBSCRIBE:
                 switch (this.currentState) {
                     case this.STATE_SUBSCRIBED:
-                        if (args?.resubscribe) {
+                        if (args?.replace) {
                             this.queue.clearPatches();
-                            this.subscribe(true);
+                            this.subscribe({ replace: true });
                         }
                         break;
 
@@ -1011,17 +1011,15 @@ class Subscription {
 
     /**
      * Try to subscribe.
-     * @param modify - The modify flag indicates that subscription action is part of subscription modification.
-     *                           If true, any unsubscribe before subscribe will be kept. Otherwise they are dropped.
      */
-    onSubscribe(resubscribe?: boolean) {
+    onSubscribe({ replace = false } = {}) {
         if (this.isDisposed) {
             throw new Error(
                 'Subscribing a disposed subscription - you will not get data',
             );
         }
 
-        this.tryPerformAction(ACTION_SUBSCRIBE, { resubscribe });
+        this.tryPerformAction(ACTION_SUBSCRIBE, { replace });
     }
 
     /**
@@ -1049,7 +1047,7 @@ class Subscription {
             }
             this.tryPerformAction(ACTION_MODIFY_PATCH, options.patchArgsDelta);
         } else if (options?.isReplace) {
-            this.onSubscribe(true);
+            this.onSubscribe({ replace: true });
         } else {
             // resubscribe with new arguments
             this.onUnsubscribe(true);


### PR DESCRIPTION
This creates a new subscription and deletes the old one in a single HTTP request.

This is:
* safer than doing a delete and create in parallel, which can hit subscription limits
* faster than waiting for the delete to return before doing the create

`PATCH` is still the preferred and most efficient full-stack way of modifying arguments, but this new option deals with the reality that many services haven't implemented it.

Internal accompanying PR: 130056