### PR TITLE
fixed _connectionheartbeat msg id issue

### DIFF
--- a/src/openapi/streaming/connection/transport/websocket-transport.spec.ts
+++ b/src/openapi/streaming/connection/transport/websocket-transport.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../../test/utils';
 import mockMathRandom from '../../../../test/mocks/math-random';
 import mockFetch from '../../../../test/mocks/fetch';
+import log from '../../../../log';
 import * as RequestUtils from '../../../../utils/request';
 import WebSocketTransport from './websocket-transport';
 import * as constants from '../constants';
@@ -346,6 +347,122 @@ describe('openapi WebSocket Transport', () => {
                 expect(spyOnFailCallback).toBeCalledTimes(1);
 
                 done();
+            });
+        });
+
+        describe('incremental message id', () => {
+            it('should log error if received websocket messages are not in incremental id fashion', (done) => {
+                const logSpy = jest.spyOn(log, 'error');
+
+                const spyOnReceivedCallback = jest
+                    .fn()
+                    .mockName('spyReceivedCallback');
+                const spyOnStartCallback = jest
+                    .fn()
+                    .mockName('spyStartCallback');
+
+                const transport = new WebSocketTransport(BASE_URL);
+                transport.setReceivedCallback(spyOnReceivedCallback);
+                transport.updateQuery(AUTH_TOKEN, CONTEXT_ID);
+                transport.start({}, spyOnStartCallback);
+                fetchMock.resolve(200, {});
+
+                transport.authorizePromise?.then(() => {
+                    const dataBuffer = new window.TextEncoder().encode(
+                        JSON.stringify(jsonPayload),
+                    );
+                    const payload = new Uint8Array(
+                        new ArrayBuffer(dataBuffer.length + 17),
+                    );
+                    payload.set(
+                        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 56, 0, 134, 12, 0, 0],
+                        0,
+                    );
+                    payload.set(dataBuffer, 17);
+                    transport.socket?.onmessage?.({
+                        data: payload.buffer,
+                    } as any);
+
+                    // send another message with same id i.e. 1
+                    transport.socket?.onmessage?.({
+                        data: payload.buffer,
+                    } as any);
+
+                    expect(logSpy).toBeCalledWith(
+                        'PlainWebSocketsTransport',
+                        'Messages out of order in websocket transport',
+                        { lastMessageId: 1, messageId: 1 },
+                    );
+                    done();
+                });
+            });
+
+            it('should skip _connectionheartbeat control message from incremental id logic', (done) => {
+                const logSpy = jest.spyOn(log, 'error');
+                const spyOnReceivedCallback = jest
+                    .fn()
+                    .mockName('spyReceivedCallback');
+                const spyOnStartCallback = jest
+                    .fn()
+                    .mockName('spyStartCallback');
+
+                const transport = new WebSocketTransport(BASE_URL);
+                transport.setReceivedCallback(spyOnReceivedCallback);
+                transport.updateQuery(AUTH_TOKEN, CONTEXT_ID);
+                transport.start({}, spyOnStartCallback);
+                fetchMock.resolve(200, {});
+
+                transport.authorizePromise?.then(() => {
+                    const dataBuffer = new window.TextEncoder().encode(
+                        JSON.stringify(jsonPayload),
+                    );
+                    const payload = new Uint8Array(
+                        new ArrayBuffer(dataBuffer.length + 17),
+                    );
+
+                    /*
+                     [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 56, 0, 134, 12, 0, 0] is parsed as:
+                     messageIdBuffer (first 8 bytes): 1, 0, 0, 0, 0, 0, 0, 0,
+                     reservedField (2 bytes): 0, 0,
+                     referenceIdSize (1 byte): 1,
+                     referenceIdBuffer (n bytes make up the reference id whose value is ASCII string): 56,
+                     dataFormat (1 byte, 0 for JSON):0,
+                     payloadSize(n bytes make up the actual payload): 134, 12, 0, 0, // since databuffer length is 3206
+                    */
+                    payload.set(
+                        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 56, 0, 134, 12, 0, 0],
+                        0,
+                    );
+                    payload.set(dataBuffer, 17);
+                    transport.socket?.onmessage?.({
+                        data: payload.buffer,
+                    } as any);
+
+                    // send _connectionheartbeat control message with same id i.e. 1
+                    const dataBuffer2 = new window.TextEncoder().encode(
+                        JSON.stringify([
+                            { ReferenceId: '_connectionheartbeat' },
+                        ]),
+                    );
+                    const payload2 = new Uint8Array(
+                        new ArrayBuffer(dataBuffer2.length + 17),
+                    );
+
+                    /*
+                     payloadSize(n bytes make up the actual payload): 40, 0, 0, 0, // since databuffer length is 40
+                    */
+                    payload2.set(
+                        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 56, 0, 40, 0, 0, 0],
+                        0,
+                    );
+                    payload2.set(dataBuffer2, 17);
+                    transport.socket?.onmessage?.({
+                        data: payload2.buffer,
+                    } as any);
+
+                    expect(logSpy).toBeCalledTimes(0);
+                    done();
+                });
             });
         });
     });

--- a/src/openapi/streaming/control-messages.ts
+++ b/src/openapi/streaming/control-messages.ts
@@ -1,5 +1,7 @@
 export const OPENAPI_CONTROL_MESSAGE_PREFIX = '_';
 export const OPENAPI_CONTROL_MESSAGE_HEARTBEAT = '_heartbeat';
+export const OPENAPI_CONTROL_MESSAGE_CONNECTION_HEARTBEAT =
+    '_connectionheartbeat';
 export const OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS =
     '_resetsubscriptions';
 export const OPENAPI_CONTROL_MESSAGE_RECONNECT = '_reconnect';

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -16,6 +16,7 @@ import {
     OPENAPI_CONTROL_MESSAGE_PREFIX,
     OPENAPI_CONTROL_MESSAGE_DISCONNECT,
     OPENAPI_CONTROL_MESSAGE_HEARTBEAT,
+    OPENAPI_CONTROL_MESSAGE_CONNECTION_HEARTBEAT,
     OPENAPI_CONTROL_MESSAGE_RECONNECT,
     OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS,
 } from './control-messages';
@@ -637,6 +638,10 @@ class Streaming extends MicroEmitter<EmittedEvents> {
 
             case OPENAPI_CONTROL_MESSAGE_DISCONNECT:
                 this.handleControlMessageDisconnect();
+                break;
+
+            case OPENAPI_CONTROL_MESSAGE_CONNECTION_HEARTBEAT:
+                // control mesage to keep streaming connection alive
                 break;
 
             default:

--- a/src/openapi/streaming/types.ts
+++ b/src/openapi/streaming/types.ts
@@ -3,6 +3,7 @@ import type { IHubProtocol } from '@microsoft/signalr';
 import type {
     OPENAPI_CONTROL_MESSAGE_DISCONNECT,
     OPENAPI_CONTROL_MESSAGE_HEARTBEAT,
+    OPENAPI_CONTROL_MESSAGE_CONNECTION_HEARTBEAT,
     OPENAPI_CONTROL_MESSAGE_RECONNECT,
     OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS,
 } from './control-messages';
@@ -52,7 +53,8 @@ export type HeartbeatsControlMessage = StreamingControlMessage<
         Heartbeats: Heartbeats[];
         ReferenceId: typeof OPENAPI_CONTROL_MESSAGE_HEARTBEAT;
     }[],
-    typeof OPENAPI_CONTROL_MESSAGE_HEARTBEAT
+    | typeof OPENAPI_CONTROL_MESSAGE_HEARTBEAT
+    | typeof OPENAPI_CONTROL_MESSAGE_CONNECTION_HEARTBEAT
 >;
 
 export type ResetControlMessage = StreamingControlMessage<


### PR DESCRIPTION
incremental message id logic was introduced in this pr: [458](https://github.com/SaxoBank/openapi-clientlib-js/pull/458/)
`_connectionheartbeat` type heart beat message don't have incremental message id implementation so these type of message are logging error.

to fix this in this pr we are just skipping `_connectionheartbeat` type messages from in the incremental message id logic.