### PR TITLE
Include contextual information in all "unanticipated state" error logs

### DIFF
--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -505,6 +505,8 @@ class Subscription {
                             {
                                 state: this.currentState,
                                 action,
+                                url: this.url,
+                                servicePath: this.servicePath,
                             },
                         );
                 }
@@ -523,6 +525,8 @@ class Subscription {
                             {
                                 state: this.currentState,
                                 action,
+                                url: this.url,
+                                servicePath: this.servicePath,
                             },
                         );
                 }
@@ -550,6 +554,8 @@ class Subscription {
                             {
                                 state: this.currentState,
                                 action,
+                                url: this.url,
+                                servicePath: this.servicePath,
                             },
                         );
                 }
@@ -569,6 +575,8 @@ class Subscription {
                             {
                                 state: this.currentState,
                                 action,
+                                url: this.url,
+                                servicePath: this.servicePath,
                             },
                         );
                 }

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -1185,7 +1185,7 @@ class Subscription {
 
             default:
                 log.error(LOG_AREA, 'Unanticipated state onStreamingData', {
-                    currentState: this.currentState,
+                    state: this.currentState,
                     url: this.url,
                     servicePath: this.servicePath,
                 });


### PR DESCRIPTION
We have many errors (with muted alerts) for "unanticipated state in X", but only a few of them have the necessary context info to be able to investigate them.

I'm not anticipating releasing this now - it can probably go with the next one.