### PR TITLE
fix ws taking long time to reconnect issue

### DIFF
--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -217,6 +217,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             parserEngines,
             parsers,
             isWebsocketStreamingHeartBeatEnabled,
+            shouldReconnectWSOnceOnline,
         } = options;
 
         this.connectionOptions = {
@@ -228,6 +229,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             // This protocol is used to serialize the message envelope rather than the payload
             messageSerializationProtocol,
             isWebsocketStreamingHeartBeatEnabled,
+            shouldReconnectWSOnceOnline,
         };
 
         if (typeof connectRetryDelay === 'number') {

--- a/src/openapi/streaming/types.ts
+++ b/src/openapi/streaming/types.ts
@@ -17,6 +17,7 @@ export interface ConnectionOptions {
     transport?: Array<TransportTypes>;
     messageSerializationProtocol?: IHubProtocol;
     isWebsocketStreamingHeartBeatEnabled?: boolean;
+    shouldReconnectWSOnceOnline?: boolean;
 }
 
 export type ConnectionState =
@@ -113,6 +114,10 @@ export interface StreamingConfigurableOptions {
      * If true we wll get streaming heartbeat messages for websocket connection
      */
     isWebsocketStreamingHeartBeatEnabled?: boolean;
+    /**
+     * If set we will trigger reconnect once client become online from offline, since last reconnect takes alot of time(30-40 seconds)
+     */
+    shouldReconnectWSOnceOnline?: boolean;
     /**
      *  Flag to control whether we should subscribe before streaming setup during initial subscribe
      */


### PR DESCRIPTION
- when client gets offline we do reconnect multiple time and each reconnect takes around 10 to 15 seconds.
- as soon as client gets online the last reconnect takes around 30 to 40 seconds before it finishes and the next reconnect call gets 101 instantly
- the idea behind this pr is to trigger a reconnect once client gets online so that we can stop the last reconnect call that takes 30 to 40 seconds so that client can get connected immediately for better user experience
- we are adding the 'online' event listener on window when websocket connection opens and removing the same when websocket connection destroys
