### PR TITLE
Handle probe messages #505

### DIFF
--- a/src/openapi/streaming/control-messages.ts
+++ b/src/openapi/streaming/control-messages.ts
@@ -6,3 +6,4 @@ export const OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS =
     '_resetsubscriptions';
 export const OPENAPI_CONTROL_MESSAGE_RECONNECT = '_reconnect';
 export const OPENAPI_CONTROL_MESSAGE_DISCONNECT = '_disconnect';
+export const OPENAPI_CONTROL_MESSAGE_PROBE = '_probe';

--- a/src/openapi/streaming/types.ts
+++ b/src/openapi/streaming/types.ts
@@ -6,6 +6,7 @@ import type {
     OPENAPI_CONTROL_MESSAGE_CONNECTION_HEARTBEAT,
     OPENAPI_CONTROL_MESSAGE_RECONNECT,
     OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS,
+    OPENAPI_CONTROL_MESSAGE_PROBE,
 } from './control-messages';
 import type { TRANSPORT_NAME_MAP } from './connection/connection';
 import type * as connectionConstants from './connection/constants';
@@ -64,6 +65,13 @@ export type ResetControlMessage = StreamingControlMessage<
     typeof OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS
 >;
 
+export type ProbeControlMessage = StreamingControlMessage<
+    {
+        ProbeId: number
+    }[],
+    typeof OPENAPI_CONTROL_MESSAGE_PROBE
+>;
+
 type ConnectionControlMessage = StreamingControlMessage<
     any,
     | typeof OPENAPI_CONTROL_MESSAGE_RECONNECT
@@ -73,7 +81,8 @@ type ConnectionControlMessage = StreamingControlMessage<
 export type ControlMessage =
     | HeartbeatsControlMessage
     | ResetControlMessage
-    | ConnectionControlMessage;
+    | ConnectionControlMessage
+    | ProbeControlMessage;
 
 export interface RetryDelayLevel {
     level: number;


### PR DESCRIPTION
Working with probes the messages will always be discarded as they are picked up for their "_" prefix but not handled. This should handle them and allow the user to specifiy a callback to be triggered which will be provided with the message from the server.