### PR TITLE
fix protobuf issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v10.4.2
+- Fix an issue with protobuf support if only SchemaName is sent
+
 ### v10.4.1
 - Changed "bearer" removal in network auth handling to work regardless of "bearer" casing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "10.4.1",
+  "version": "10.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.4.1",
+    "version": "10.4.2",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/streaming/parser/parser-protobuf.ts
+++ b/src/openapi/streaming/parser/parser-protobuf.ts
@@ -185,6 +185,7 @@ class ParserProtobuf extends ParserBase {
                 error,
                 base64Data,
                 schema: this.schemasSourceMap[schemaName],
+                schemaName,
             });
             throw new Error('Parsing failed');
         }


### PR DESCRIPTION
We agreed that in order to fix a issue with open api rollout changing the SchemaName, we need to include only the schema name in all responses. But this is breaking the app because we only set this.SchemaName when both schema name and schema is present.