### PR TITLE
Make protobuf fallback to json

### DIFF
--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -717,7 +717,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
     private resetSubscriptions(subscriptions: Subscription[]) {
         for (let i = 0; i < subscriptions.length; i++) {
             const subscription = subscriptions[i];
-            subscription.reset();
+            subscription.reset(true);
         }
     }
 
@@ -941,7 +941,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
         }
 
         this.connection.onOrphanFound();
-        subscription.reset();
+        subscription.reset(false);
     }
 
     private handleSubscriptionReadyForUnsubscribe(
@@ -1222,7 +1222,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             const subscription = this.subscriptions[i];
             // Reset the subscription and mark it as not having a connection so its state becomes unsubscribed
             // next action if there is any i.e. subscribe will go in the queue until the connection is available again
-            subscription.reset();
+            subscription.unsubscribeAndSubscribe();
             subscription.onConnectionUnavailable();
         }
 
@@ -1251,7 +1251,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             // disconnecting *should* shut down all subscriptions. We also delete all below.
             // So mark the subscription as not having a connection and reset it so its state becomes unsubscribed
             subscription.onConnectionUnavailable();
-            subscription.reset();
+            subscription.dispose();
         }
         this.subscriptions.length = 0;
 

--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -1335,7 +1335,7 @@ describe('openapi StreamingSubscription', () => {
                 createdSpy,
             );
 
-            subscription.reset(); // reset before subscribed
+            subscription.reset(true); // reset before subscribed
 
             expect(transport.post.mock.calls.length).toEqual(0);
             expect(transport.delete.mock.calls.length).toEqual(0);
@@ -1352,7 +1352,7 @@ describe('openapi StreamingSubscription', () => {
                 transport.delete.mockClear();
 
                 let oldReferenceId = subscription.referenceId;
-                subscription.reset(); // reset when trying to unsubscribe
+                subscription.reset(true); // reset when trying to unsubscribe
                 expect(oldReferenceId).toEqual(subscription.referenceId); // don't need to change as not subscribing
 
                 expect(transport.post.mock.calls.length).toEqual(0);
@@ -1361,7 +1361,7 @@ describe('openapi StreamingSubscription', () => {
                 transport.deleteResolve({ status: 200 });
                 setTimeout(() => {
                     oldReferenceId = subscription.referenceId;
-                    subscription.reset(); // reset when unsubscribed
+                    subscription.reset(true); // reset when unsubscribed
                     expect(oldReferenceId).toEqual(subscription.referenceId); // don't need to change as not subscribing
 
                     expect(transport.post.mock.calls.length).toEqual(0);
@@ -1383,7 +1383,7 @@ describe('openapi StreamingSubscription', () => {
                 createdSpy,
             );
 
-            subscription.reset(); // reset before subscribed
+            subscription.reset(true); // reset before subscribed
 
             expect(transport.post.mock.calls.length).toEqual(0);
             expect(transport.delete.mock.calls.length).toEqual(0);
@@ -1401,7 +1401,7 @@ describe('openapi StreamingSubscription', () => {
                 transport.delete.mockClear();
 
                 let oldReferenceId = subscription.referenceId;
-                subscription.reset(); // reset when trying to unsubscribe
+                subscription.reset(true); // reset when trying to unsubscribe
                 expect(oldReferenceId).toEqual(subscription.referenceId); // don't need to change as not subscribing
 
                 expect(transport.post.mock.calls.length).toEqual(0);
@@ -1450,7 +1450,7 @@ describe('openapi StreamingSubscription', () => {
                   ],
                 }
             `);
-            subscription.reset();
+            subscription.reset(true);
             expect(subscription.currentState).toEqual(
                 subscription.STATE_SUBSCRIBE_REQUESTED,
             );
@@ -1486,7 +1486,7 @@ describe('openapi StreamingSubscription', () => {
             expect(transport.delete.mock.calls.length).toEqual(0);
 
             const oldReferenceId = subscription.referenceId;
-            subscription.reset(); // reset before subscribe response
+            subscription.reset(true); // reset before subscribe response
             expect(subscription.currentState).toEqual(
                 subscription.STATE_SUBSCRIBE_REQUESTED,
             );
@@ -1567,7 +1567,7 @@ describe('openapi StreamingSubscription', () => {
             expect(transport.delete.mock.calls.length).toEqual(0);
 
             const oldReferenceId = subscription.referenceId;
-            subscription.reset(); // reset before subscribe response
+            subscription.reset(true); // reset before subscribe response
             expect(subscription.currentState).toEqual(
                 subscription.STATE_SUBSCRIBE_REQUESTED,
             );
@@ -1645,7 +1645,7 @@ describe('openapi StreamingSubscription', () => {
                 // normally subscribed
 
                 const oldReferenceId = subscription.referenceId;
-                subscription.reset();
+                subscription.reset(true);
 
                 // sends delete request for old subscription
                 expect(transport.delete.mock.calls.length).toEqual(1);
@@ -1692,7 +1692,7 @@ describe('openapi StreamingSubscription', () => {
                 // normally subscribed
 
                 const oldReferenceId = subscription.referenceId;
-                subscription.reset();
+                subscription.reset(true);
 
                 // sends delete request for old subscription
                 expect(transport.delete.mock.calls.length).toEqual(1);
@@ -1725,9 +1725,9 @@ describe('openapi StreamingSubscription', () => {
                     { onUpdate: updateSpy },
                 );
 
-                subscription.reset();
-                subscription.reset();
-                subscription.reset();
+                subscription.reset(true);
+                subscription.reset(true);
+                subscription.reset(true);
 
                 expect(subscription.currentState).toEqual(
                     subscription.STATE_PUBLISHER_DOWN,
@@ -1758,9 +1758,9 @@ describe('openapi StreamingSubscription', () => {
                     { onUpdate: updateSpy },
                 );
 
-                subscription.reset();
-                subscription.reset();
-                subscription.reset();
+                subscription.reset(true);
+                subscription.reset(true);
+                subscription.reset(true);
 
                 expect(subscription.currentState).toEqual(
                     subscription.STATE_PUBLISHER_DOWN,
@@ -2235,7 +2235,7 @@ describe('openapi StreamingSubscription', () => {
                 expect(subscription.currentState).toEqual(
                     subscription.STATE_PATCH_REQUESTED,
                 );
-                subscription.reset();
+                subscription.reset(true);
                 expect(subscription.currentState).toEqual(
                     subscription.STATE_UNSUBSCRIBE_REQUESTED,
                 );
@@ -2286,7 +2286,7 @@ describe('openapi StreamingSubscription', () => {
                 expect(subscription.currentState).toEqual(
                     subscription.STATE_PATCH_REQUESTED,
                 );
-                subscription.reset();
+                subscription.reset(true);
                 expect(subscription.currentState).toEqual(
                     subscription.STATE_UNSUBSCRIBE_REQUESTED,
                 );

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -253,9 +253,9 @@ class Subscription {
 
     /**
      * If we get 3 resets within 1 minute then we wait for 1 minute
-     * since it may indicate some problem with publishers
+     * since it may indicate some problem with publishers or the frontend
      */
-    private checkIfPublisherDown() {
+    private checkIfPublisherDown(isServerInitiated: boolean) {
         this.resetTimeStamps.push(Date.now());
 
         if (this.resetTimeStamps.length >= 3) {
@@ -265,8 +265,14 @@ class Subscription {
                 this.resetTimeStamps[2] - this.resetTimeStamps[0] <
                     MIN_WAIT_FOR_PUBLISHER_TO_RESPOND_MS
             ) {
-                // 3 reset within 1 minute so wait for 1 minute for pubslisher to respond
-                log.warn(LOG_AREA, 'Received 3 resets within 1 minute');
+                // 3 reset within 1 minute so wait for 1 minute for publisher to respond
+                // this can also happen due to errors client side and in this case
+                // this code prevents us from spamming the servers
+                log.warn(LOG_AREA, '3 resets occurred within 1 minute.', {
+                    url: this.url,
+                    servicePath: this.servicePath,
+                    isServerInitiated,
+                });
                 this.setState(this.STATE_PUBLISHER_DOWN);
 
                 this.waitForPublisherToRespondTimer = window.setTimeout(() => {
@@ -667,7 +673,13 @@ class Subscription {
         }
         this.updatesBeforeSubscribed = null;
 
-        this.onReadyToPerformNextAction();
+        // if processing the updatesBeforeSubscribed received above goes wrong or there
+        // is a failure to add the schema, a reset
+        // may occur and the state may now be unsubscribe requested.
+        // if that is the case, we should not try and do anything here
+        if (this.currentState === this.STATE_SUBSCRIBED) {
+            this.onReadyToPerformNextAction();
+        }
     }
 
     private cleanUpLeftOverSubscription(referenceId: string) {
@@ -755,12 +767,7 @@ class Subscription {
             );
 
             // Fallback to JSON format if specific endpoint doesn't support PROTOBUF format.
-            this.subscriptionData.Format = FORMAT_JSON;
-            this.parser = ParserFacade.getParser(
-                FORMAT_JSON,
-                this.servicePath,
-                this.url,
-            );
+            this.fallbackToJSON();
 
             if (!willUnsubscribe) {
                 this.tryPerformAction(ACTION_SUBSCRIBE);
@@ -964,17 +971,38 @@ class Subscription {
                 url: this.url,
             });
 
-            // if we cannot understand an update we should re-subscribe to make sure we are updated
-            this.reset();
+            // if we cannot understand an update we should re-subscribe and fallback to JSON
+            this.fallbackToJSON();
+            this.reset(false);
             return;
         }
 
         this.onUpdate?.(nextMessage, type);
     }
 
+    private fallbackToJSON() {
+        this.subscriptionData.Format = FORMAT_JSON;
+        this.parser = ParserFacade.getParser(
+            FORMAT_JSON,
+            this.servicePath,
+            this.url,
+        );
+    }
+
     processSnapshot(response: SubscriptionSuccessResult) {
         if (response.Schema && response.SchemaName) {
-            this.parser.addSchema(response.Schema, response.SchemaName);
+            try {
+                this.parser.addSchema(response.Schema, response.SchemaName);
+            } catch (error) {
+                log.error(
+                    LOG_AREA,
+                    'Fallback to json after failure to add schema',
+                    { error },
+                );
+                this.fallbackToJSON();
+                this.reset(false);
+                return;
+            }
         }
 
         if (response.SchemaName) {
@@ -987,11 +1015,7 @@ class Subscription {
                 if (!this.SchemaName) {
                     // If SchemaName is missing both in response and parser cache, it means that openapi doesn't support protobuf for this endpoint.
                     // In such scenario, falling back to default parser.
-                    this.parser = ParserFacade.getParser(
-                        ParserFacade.getDefaultFormat(),
-                        this.servicePath,
-                        this.url,
-                    );
+                    this.fallbackToJSON();
                 } else {
                     // when open api has upgraded this should be a warn
                     log.info(
@@ -1020,8 +1044,17 @@ class Subscription {
      * can ignore them. It also ensures that we don't hit the subscription limit
      * because the subscribe manages to get to the server before the unsubscribe.
      */
-    reset() {
-        this.checkIfPublisherDown();
+    reset(isServerInitiated: boolean) {
+        this.checkIfPublisherDown(isServerInitiated);
+        this.unsubscribeAndSubscribe();
+    }
+
+    /**
+     * Does a unsubscribe and then schedules a subscribe for when it is finished unsubscribing
+     * Call this only if this is not a error scenario. Normally you should use reset
+     * So that we track the reset
+     */
+    unsubscribeAndSubscribe() {
         switch (this.currentState) {
             case this.STATE_UNSUBSCRIBED:
             case this.STATE_UNSUBSCRIBE_REQUESTED:
@@ -1136,6 +1169,8 @@ class Subscription {
      */
     dispose() {
         this.isDisposed = true;
+        this.currentState = this.STATE_UNSUBSCRIBED;
+        this.queue.reset();
     }
 
     /**


### PR DESCRIPTION
This PR contains some fixes that came out of the bug with protobuf SchemaName fixed previously.

1. We should switch back to json if we get a protobuf error
2. We should be careful when we reset so we don't trigger the warning due to normal behaviour
3. We should log information on what is causing the 3 resets error message
4. If a update comes in before a snapshot and we process it during the initial snapshot and then get a parser error, we can swallow the subscribe part of the reset and so stay in the unsubscribed state

Testing:
- [x] I tested by rebasing this before the protobuf fix and verified that fallback to JSON works.

TODO:
- [ ] Unit tests covering old and new SchemaName behavior
- [ ] Unit tests covering fallback to JSON
- [ ] Unit tests covering errors processing the snapshot, so we do not unsubscribe and swallow the subscribe