### PR TITLE
Support cloud streaming control message format

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v10.5.0
+- Add support for cloud streaming control message format
+
 ### v10.4.2
 - Fix an issue with protobuf support if only SchemaName is sent
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-clientlib",
-  "version": "10.4.2",
+  "version": "10.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.4.2",
+    "version": "10.5.0",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/streaming/streaming.spec.ts
+++ b/src/openapi/streaming/streaming.spec.ts
@@ -835,8 +835,23 @@ describe('openapi Streaming', () => {
                 {
                     ReferenceId: '_heartbeat',
                     Data: [
-                        { Heartbeats: [{ OriginatingReferenceId: 'MySpy' }] },
+                        {
+                            ReferenceId: '_heartbeat',
+                            Heartbeats: [{ OriginatingReferenceId: 'MySpy' }],
+                        },
                     ],
+                },
+            ]);
+            expect(subscription.onHeartbeat.mock.calls.length).toEqual(1);
+            expect(subscription.onHeartbeat.mock.calls[0]).toEqual([]);
+            expect(subscription.reset.mock.calls.length).toEqual(0);
+        });
+        it('handles heartbeats in data object', () => {
+            expect(subscription.onHeartbeat.mock.calls.length).toEqual(0);
+            receivedCallback([
+                {
+                    ReferenceId: '_heartbeat',
+                    Data: { Heartbeats: [{ OriginatingReferenceId: 'MySpy' }] },
                 },
             ]);
             expect(subscription.onHeartbeat.mock.calls.length).toEqual(1);
@@ -868,7 +883,22 @@ describe('openapi Streaming', () => {
             receivedCallback([
                 {
                     ReferenceId: '_resetsubscriptions',
-                    Data: [{ TargetReferenceIds: ['MySpy'] }],
+                    Data: [
+                        {
+                            ReferenceId: '_resetsubscriptions',
+                            TargetReferenceIds: ['MySpy'],
+                        },
+                    ],
+                },
+            ]);
+            expect(subscription.reset.mock.calls.length).toEqual(1);
+            expect(subscription.reset.mock.calls[0]).toEqual([]);
+        });
+        it('handles reset in data object', () => {
+            receivedCallback([
+                {
+                    ReferenceId: '_resetsubscriptions',
+                    Data: { TargetReferenceIds: ['MySpy'] },
                 },
             ]);
             expect(subscription.reset.mock.calls.length).toEqual(1);
@@ -887,7 +917,21 @@ describe('openapi Streaming', () => {
             receivedCallback([
                 {
                     ReferenceId: '_resetsubscriptions',
-                    Data: [{ TargetReferenceIds: ['foo'] }],
+                    Data: [
+                        {
+                            ReferenceId: '_resetsubscriptions',
+                            TargetReferenceIds: ['foo'],
+                        },
+                    ],
+                },
+            ]);
+            expect(subscription.reset.mock.calls.length).toEqual(0);
+        });
+        it('handles and ignores reset for a subscription not present in data object', () => {
+            receivedCallback([
+                {
+                    ReferenceId: '_resetsubscriptions',
+                    Data: { TargetReferenceIds: ['foo'] },
                 },
             ]);
             expect(subscription.reset.mock.calls.length).toEqual(0);

--- a/src/openapi/streaming/streaming.spec.ts
+++ b/src/openapi/streaming/streaming.spec.ts
@@ -869,6 +869,18 @@ describe('openapi Streaming', () => {
             expect(subscription.onHeartbeat.mock.calls.length).toEqual(0);
             expect(subscription.reset.mock.calls.length).toEqual(0);
         });
+        it('Logs a warning on unsupported heartbeat message format', () => {
+            const warnLogSpy = jest.spyOn(log, 'warn');
+            expect(subscription.onHeartbeat.mock.calls.length).toEqual(0);
+            receivedCallback([
+                {
+                    ReferenceId: '_heartbeat',
+                    SomeProp: { Heartbeats: { foo: 'bar' } },
+                },
+            ]);
+            expect(subscription.onHeartbeat.mock.calls.length).toEqual(0);
+            expect(warnLogSpy).toHaveBeenCalledTimes(1);
+        });
         it('handles reset', () => {
             receivedCallback([
                 {
@@ -937,9 +949,11 @@ describe('openapi Streaming', () => {
             expect(subscription.reset.mock.calls.length).toEqual(0);
         });
         it('handles reset all', () => {
+            const warnLogSpy = jest.spyOn(log, 'warn');
             receivedCallback([{ ReferenceId: '_resetsubscriptions' }]);
             expect(subscription.reset.mock.calls.length).toEqual(1);
             expect(subscription.reset.mock.calls[0]).toEqual([]);
+            expect(warnLogSpy).toHaveBeenCalledTimes(1);
         });
         it('handles reset all for empty TargetReferenceIds array', () => {
             receivedCallback([

--- a/src/openapi/streaming/streaming.spec.ts
+++ b/src/openapi/streaming/streaming.spec.ts
@@ -829,6 +829,20 @@ describe('openapi Streaming', () => {
             expect(subscription.onHeartbeat.mock.calls[0]).toEqual([]);
             expect(subscription.reset.mock.calls.length).toEqual(0);
         });
+        it('handles heartbeats in data array', () => {
+            expect(subscription.onHeartbeat.mock.calls.length).toEqual(0);
+            receivedCallback([
+                {
+                    ReferenceId: '_heartbeat',
+                    Data: [
+                        { Heartbeats: [{ OriginatingReferenceId: 'MySpy' }] },
+                    ],
+                },
+            ]);
+            expect(subscription.onHeartbeat.mock.calls.length).toEqual(1);
+            expect(subscription.onHeartbeat.mock.calls[0]).toEqual([]);
+            expect(subscription.reset.mock.calls.length).toEqual(0);
+        });
         it('handles and ignores heartbeats for a subscription not present', () => {
             expect(subscription.onHeartbeat.mock.calls.length).toEqual(0);
             receivedCallback([
@@ -850,11 +864,30 @@ describe('openapi Streaming', () => {
             expect(subscription.reset.mock.calls.length).toEqual(1);
             expect(subscription.reset.mock.calls[0]).toEqual([]);
         });
+        it('handles reset in data array', () => {
+            receivedCallback([
+                {
+                    ReferenceId: '_resetsubscriptions',
+                    Data: [{ TargetReferenceIds: ['MySpy'] }],
+                },
+            ]);
+            expect(subscription.reset.mock.calls.length).toEqual(1);
+            expect(subscription.reset.mock.calls[0]).toEqual([]);
+        });
         it('handles and ignores reset for a subscription not present', () => {
             receivedCallback([
                 {
                     ReferenceId: '_resetsubscriptions',
                     TargetReferenceIds: ['foo'],
+                },
+            ]);
+            expect(subscription.reset.mock.calls.length).toEqual(0);
+        });
+        it('handles and ignores reset for a subscription not present in data array', () => {
+            receivedCallback([
+                {
+                    ReferenceId: '_resetsubscriptions',
+                    Data: [{ TargetReferenceIds: ['foo'] }],
                 },
             ]);
             expect(subscription.reset.mock.calls.length).toEqual(0);

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -604,7 +604,19 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             return message.Heartbeats;
         }
 
-        if (message.Data && message.Data.length > 0) {
+        if (
+            message.Data &&
+            !Array.isArray(message.Data) &&
+            message.Data.Heartbeats
+        ) {
+            return message.Data.Heartbeats;
+        }
+
+        if (
+            message.Data &&
+            Array.isArray(message.Data) &&
+            message.Data.length > 0
+        ) {
             return message.Data[0].Heartbeats;
         }
 
@@ -616,7 +628,19 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             return message.TargetReferenceIds;
         }
 
-        if (message.Data && message.Data.length > 0) {
+        if (
+            message.Data &&
+            !Array.isArray(message.Data) &&
+            message.Data.TargetReferenceIds
+        ) {
+            return message.Data.TargetReferenceIds;
+        }
+
+        if (
+            message.Data &&
+            Array.isArray(message.Data) &&
+            message.Data.length > 0
+        ) {
             return message.Data[0].TargetReferenceIds;
         }
 

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -620,6 +620,10 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             return message.Data[0].Heartbeats;
         }
 
+        log.warn(LOG_AREA, 'Unrecognised heartbeat message', {
+            message,
+        });
+
         return [];
     }
 
@@ -643,6 +647,10 @@ class Streaming extends MicroEmitter<EmittedEvents> {
         ) {
             return message.Data[0].TargetReferenceIds;
         }
+
+        log.warn(LOG_AREA, 'Unrecognised reset message', {
+            message,
+        });
 
         return null;
     }

--- a/src/openapi/streaming/types.ts
+++ b/src/openapi/streaming/types.ts
@@ -50,18 +50,24 @@ type StreamingControlMessage<T = StreamingData, R = string> = StreamingMessage<
 >;
 
 export type HeartbeatsControlMessage = StreamingControlMessage<
-    {
-        Heartbeats: Heartbeats[];
-        ReferenceId: typeof OPENAPI_CONTROL_MESSAGE_HEARTBEAT;
-    }[],
+    | {
+          Heartbeats: Heartbeats[];
+          ReferenceId: typeof OPENAPI_CONTROL_MESSAGE_HEARTBEAT;
+      }[]
+    | {
+          Heartbeats: Heartbeats[];
+      },
     | typeof OPENAPI_CONTROL_MESSAGE_HEARTBEAT
     | typeof OPENAPI_CONTROL_MESSAGE_CONNECTION_HEARTBEAT
 >;
 
 export type ResetControlMessage = StreamingControlMessage<
-    {
-        TargetReferenceIds: string[];
-    }[],
+    | {
+          TargetReferenceIds: string[];
+      }[]
+    | {
+          TargetReferenceIds: string[];
+      },
     typeof OPENAPI_CONTROL_MESSAGE_RESET_SUBSCRIPTIONS
 >;
 


### PR DESCRIPTION
Add tests for the current message format.
Add tests and support for the new message format.
Log warnings when unsupported messages are found to find problems more quickly.