### PR TITLE
Expose token refresh failure status

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v10.6.6
+- Expose result object when authorization token failure occurs due to auth issue
+
 ### v10.6.5
 - Fix a bug introduced in 10.6.2 where removing a subscription may cause the snapshot event to still fire
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.6.5",
+    "version": "10.6.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.6.5",
+    "version": "10.6.6",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/authProvider.spec.ts
+++ b/src/openapi/authProvider.spec.ts
@@ -200,6 +200,37 @@ describe('openapi AuthProvider', () => {
                 });
             });
 
+            it('fires an event if unauthorized - 407', function (done) {
+                const options = {
+                    token: 'TOKEN',
+                    expiry: relativeDate(60),
+                    tokenRefreshUrl: 'http://refresh',
+                };
+                authProvider = new AuthProvider(options);
+
+                const tokenRefreshFailSpy = jest
+                    .fn()
+                    .mockName('tokenRefreshFail listener');
+                const tokenReceivedSpy = jest
+                    .fn()
+                    .mockName('tokenReceived listener');
+                authProvider.on(
+                    authProvider.EVENT_TOKEN_REFRESH_FAILED,
+                    tokenRefreshFailSpy,
+                );
+                authProvider.on(
+                    authProvider.EVENT_TOKEN_RECEIVED,
+                    tokenReceivedSpy,
+                );
+
+                tick(60000);
+                fetch.resolve(407, { error: 'not authorised' });
+                setTimeout(function () {
+                    expect(tokenRefreshFailSpy.mock.calls.length).toEqual(1);
+                    done();
+                });
+            });
+
             it('fires an event if forbidden', function (done) {
                 const options = {
                     token: 'TOKEN',

--- a/src/openapi/authProvider.spec.ts
+++ b/src/openapi/authProvider.spec.ts
@@ -227,6 +227,10 @@ describe('openapi AuthProvider', () => {
                 fetch.resolve(407, { error: 'not authorised' });
                 setTimeout(function () {
                     expect(tokenRefreshFailSpy.mock.calls.length).toEqual(1);
+                    expect(tokenRefreshFailSpy).toHaveBeenCalledWith(
+                        expect.objectContaining({ status: 407 }),
+                    );
+
                     done();
                 });
             });

--- a/src/openapi/authProvider.ts
+++ b/src/openapi/authProvider.ts
@@ -99,7 +99,7 @@ const EVENT_TOKEN_REFRESH_FAILED = 'tokenRefreshFailed' as const;
 type EmittedEvents = {
     [EVENT_TOKEN_REFRESH]: () => void;
     [EVENT_TOKEN_RECEIVED]: (token?: string, refresh?: number) => void;
-    [EVENT_TOKEN_REFRESH_FAILED]: () => void;
+    [EVENT_TOKEN_REFRESH_FAILED]: (code?: number) => void;
 };
 
 /**
@@ -256,7 +256,10 @@ class AuthProvider extends MicroEmitter<EmittedEvents> {
     ) => {
         const currentExpiry = this.getExpiry();
         const isAuthenticationError =
-            result && (result.status === 401 || result.status === 403);
+            result &&
+            (result.status === 401 ||
+                result.status === 403 ||
+                result.status === 407);
 
         // we only log this as an error if its abnormal e.g. it is not
         //   1. a network error
@@ -274,7 +277,7 @@ class AuthProvider extends MicroEmitter<EmittedEvents> {
         }
 
         if (isAuthenticationError) {
-            this.trigger(this.EVENT_TOKEN_REFRESH_FAILED);
+            this.trigger(this.EVENT_TOKEN_REFRESH_FAILED, result.status);
             this.state = STATE_FAILED;
             return;
         }

--- a/src/openapi/authProvider.ts
+++ b/src/openapi/authProvider.ts
@@ -99,7 +99,7 @@ const EVENT_TOKEN_REFRESH_FAILED = 'tokenRefreshFailed' as const;
 type EmittedEvents = {
     [EVENT_TOKEN_REFRESH]: () => void;
     [EVENT_TOKEN_RECEIVED]: (token?: string, refresh?: number) => void;
-    [EVENT_TOKEN_REFRESH_FAILED]: (code?: number) => void;
+    [EVENT_TOKEN_REFRESH_FAILED]: (result?: OAPIRequestResult) => void;
 };
 
 /**
@@ -277,7 +277,11 @@ class AuthProvider extends MicroEmitter<EmittedEvents> {
         }
 
         if (isAuthenticationError) {
-            this.trigger(this.EVENT_TOKEN_REFRESH_FAILED, result.status);
+            // status is not present on NetworkError
+            this.trigger(
+                this.EVENT_TOKEN_REFRESH_FAILED,
+                result as OAPIRequestResult,
+            );
             this.state = STATE_FAILED;
             return;
         }


### PR DESCRIPTION
In case of a token refresh failure due to authorization error we expose the status with which the request failed. Based on that info different actions on the consumer side can be undertaken.

Adds test covering 407 status code (proxy authentication error).