### PR TITLE
Fix a bug with removing during connection issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -222,7 +222,7 @@
             {
                 "skipBlankLines": true,
                 "skipComments": true,
-                "max": 900
+                "max": 950
             }
         ],
         "max-nested-callbacks": ["error", 3],

--- a/src/openapi/streaming/streaming-websocket.spec.ts
+++ b/src/openapi/streaming/streaming-websocket.spec.ts
@@ -126,6 +126,7 @@ describe('openapi Streaming', () => {
             reset: jest.fn(),
             onSubscribe: jest.fn(),
             onUnsubscribe: jest.fn(),
+            onRemove: jest.fn(),
             onModify: jest.fn(),
             dispose: jest.fn(),
             referenceId: '',
@@ -699,22 +700,19 @@ describe('openapi Streaming', () => {
             streaming.disposeSubscription(subscription);
 
             expect(subscription.onUnsubscribe.mock.calls.length).toEqual(1);
-            expect(subscription.dispose.mock.calls.length).toEqual(1);
-            expect(streaming.subscriptions.length).toEqual(1);
+            expect(subscription.onRemove.mock.calls.length).toEqual(1);
 
             streaming.disposeSubscription(subscription2);
 
             expect(subscription2.onUnsubscribe.mock.calls.length).toEqual(1);
-            expect(subscription2.dispose.mock.calls.length).toEqual(1);
-            expect(streaming.subscriptions.length).toEqual(0);
+            expect(subscription2.onRemove.mock.calls.length).toEqual(1);
 
             // copes with being called twice
 
             streaming.disposeSubscription(subscription2);
 
             expect(subscription2.onUnsubscribe.mock.calls.length).toEqual(2);
-            expect(subscription2.dispose.mock.calls.length).toEqual(2);
-            expect(streaming.subscriptions.length).toEqual(0);
+            expect(subscription2.onRemove.mock.calls.length).toEqual(2);
         });
     });
 

--- a/src/openapi/streaming/streaming.spec.ts
+++ b/src/openapi/streaming/streaming.spec.ts
@@ -118,7 +118,7 @@ describe('openapi Streaming', () => {
             onSubscribe: jest.fn(),
             onUnsubscribe: jest.fn(),
             onModify: jest.fn(),
-            dispose: jest.fn(),
+            onRemove: jest.fn(),
             timeTillOrphaned: jest.fn(),
             addStateChangedCallback,
             removeStateChangedCallback,
@@ -1018,7 +1018,7 @@ describe('openapi Streaming', () => {
         });
     });
 
-    describe('dispose', () => {
+    describe('onRemove', () => {
         it('unsubscribes everything', () => {
             const streaming = new Streaming(transport, 'testUrl', authProvider);
             stateChangedCallback({ newState: 1 /* connected */ });
@@ -1063,6 +1063,7 @@ describe('openapi Streaming', () => {
             subscription.referenceId = 'MySpy';
             // @ts-expect-error using mocked subscription
             streaming.subscriptions.push(subscription);
+
             const subscription2 = mockSubscription();
             subscription2.referenceId = 'MySpy';
             // @ts-expect-error using mocked subscription
@@ -1072,22 +1073,19 @@ describe('openapi Streaming', () => {
             streaming.disposeSubscription(subscription);
 
             expect(subscription.onUnsubscribe.mock.calls.length).toEqual(1);
-            expect(subscription.dispose.mock.calls.length).toEqual(1);
-            expect(streaming.subscriptions.length).toEqual(1);
+            expect(subscription.onRemove.mock.calls.length).toEqual(1);
             // @ts-expect-error using mocked subscription
             streaming.disposeSubscription(subscription2);
 
             expect(subscription2.onUnsubscribe.mock.calls.length).toEqual(1);
-            expect(subscription2.dispose.mock.calls.length).toEqual(1);
-            expect(streaming.subscriptions.length).toEqual(0);
+            expect(subscription2.onRemove.mock.calls.length).toEqual(1);
 
             // copes with being called twice
             // @ts-expect-error using mocked subscription
             streaming.disposeSubscription(subscription2);
 
             expect(subscription2.onUnsubscribe.mock.calls.length).toEqual(2);
-            expect(subscription2.dispose.mock.calls.length).toEqual(2);
-            expect(streaming.subscriptions.length).toEqual(0);
+            expect(subscription2.onRemove.mock.calls.length).toEqual(2);
         });
     });
 

--- a/src/openapi/streaming/streaming.spec.ts
+++ b/src/openapi/streaming/streaming.spec.ts
@@ -124,6 +124,7 @@ describe('openapi Streaming', () => {
             removeStateChangedCallback,
             referenceId: '',
             onActivity: jest.fn(),
+            dispose: jest.fn(),
         };
 
         return mock;

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -1048,7 +1048,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
                 subscription.onUnsubscribeByTagPending();
 
                 if (shouldDisposeSubscription) {
-                    this.removeSubscription(subscription);
+                    subscription.onRemove();
                 }
             }
         }).then(() => {
@@ -1103,14 +1103,6 @@ class Streaming extends MicroEmitter<EmittedEvents> {
         });
     }
 
-    private removeSubscription(subscription: Subscription) {
-        subscription.dispose();
-        const indexOfSubscription = this.subscriptions.indexOf(subscription);
-        if (indexOfSubscription >= 0) {
-            this.subscriptions.splice(indexOfSubscription, 1);
-        }
-    }
-
     private onSubscribeNetworkError() {
         this.connection.onSubscribeNetworkError();
     }
@@ -1143,19 +1135,28 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             normalizedSubscriptionArgs.Format = ParserFacade.getDefaultFormat();
         }
 
-        options = {
-            onNetworkError: this.onSubscribeNetworkError.bind(this),
+        let subscription: Subscription;
+
+        const internalOptions = {
             ...options,
+            onNetworkError: this.onSubscribeNetworkError.bind(this),
+            onSubscriptionReadyToRemove: () => {
+                const indexOfSubscription =
+                    this.subscriptions.indexOf(subscription);
+                if (indexOfSubscription >= 0) {
+                    this.subscriptions.splice(indexOfSubscription, 1);
+                }
+            },
         };
 
-        const subscription = new Subscription(
+        subscription = new Subscription(
             this.contextId, // assuming contextId exists at this stage
             this.transport,
             servicePath,
             url,
             normalizedSubscriptionArgs,
             this.onSubscriptionCreated.bind(this),
-            options,
+            internalOptions,
         );
 
         this.subscriptions.push(subscription);
@@ -1218,7 +1219,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
      */
     disposeSubscription(subscription: Subscription) {
         this.unsubscribe(subscription);
-        this.removeSubscription(subscription);
+        subscription.onRemove();
     }
 
     /**

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -1106,9 +1106,38 @@ class Streaming extends MicroEmitter<EmittedEvents> {
     private onSubscribeNetworkError() {
         this.connection.onSubscribeNetworkError();
     }
-
+    
     private onSubscriptionReset() {
         this.resetSubscriptions(this.subscriptions, false);
+    }
+
+    private onSubscriptionReadyToRemove(subscription: Subscription) {
+        try {
+            const indexOfSubscription =
+                this.subscriptions.indexOf(subscription);
+            const { url, streamingContextId, referenceId, currentState } =
+                subscription;
+            if (indexOfSubscription >= 0) {
+                log.debug(LOG_AREA, 'Removing subscription', {
+                    url,
+                    streamingContextId,
+                    referenceId,
+                    currentState,
+                });
+                this.subscriptions.splice(indexOfSubscription, 1);
+            } else {
+                log.warn(LOG_AREA, 'Unable to find subscription', {
+                    url,
+                    streamingContextId,
+                    referenceId,
+                    currentState,
+                });
+            }
+        } catch (error) {
+            log.error(LOG_AREA, 'Error in onSubscriptionReadyToRemove', {
+                error,
+            });
+        }
     }
 
     /**
@@ -1135,28 +1164,19 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             normalizedSubscriptionArgs.Format = ParserFacade.getDefaultFormat();
         }
 
-        let subscription: Subscription;
-
-        const internalOptions = {
-            ...options,
-            onNetworkError: this.onSubscribeNetworkError.bind(this),
-            onSubscriptionReadyToRemove: () => {
-                const indexOfSubscription =
-                    this.subscriptions.indexOf(subscription);
-                if (indexOfSubscription >= 0) {
-                    this.subscriptions.splice(indexOfSubscription, 1);
-                }
-            },
-        };
-
-        subscription = new Subscription(
+        const subscription: Subscription = new Subscription(
             this.contextId, // assuming contextId exists at this stage
             this.transport,
             servicePath,
             url,
             normalizedSubscriptionArgs,
-            this.onSubscriptionCreated.bind(this),
-            internalOptions,
+            {
+                ...options,
+                onSubscriptionCreated: this.onSubscriptionCreated.bind(this),
+                onNetworkError: this.onSubscribeNetworkError.bind(this),
+                onSubscriptionReadyToRemove:
+                    this.onSubscriptionReadyToRemove.bind(this),
+            },
         );
 
         this.subscriptions.push(subscription);

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -1106,7 +1106,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
     private onSubscribeNetworkError() {
         this.connection.onSubscribeNetworkError();
     }
-    
+
     private onSubscriptionReset() {
         this.resetSubscriptions(this.subscriptions, false);
     }

--- a/src/openapi/streaming/subscription-actions.ts
+++ b/src/openapi/streaming/subscription-actions.ts
@@ -4,6 +4,7 @@ export const ACTION_MODIFY = 0x4 as const;
 export const ACTION_MODIFY_PATCH = 0x8 as const;
 export const ACTION_MODIFY_REPLACE = 0x10 as const;
 export const ACTION_UNSUBSCRIBE_BY_TAG_PENDING = 0x20 as const;
+export const ACTION_REMOVE = 0x40 as const;
 
 export type SubscriptionAction =
     | typeof ACTION_SUBSCRIBE
@@ -11,4 +12,5 @@ export type SubscriptionAction =
     | typeof ACTION_MODIFY
     | typeof ACTION_MODIFY_PATCH
     | typeof ACTION_MODIFY_REPLACE
-    | typeof ACTION_UNSUBSCRIBE_BY_TAG_PENDING;
+    | typeof ACTION_UNSUBSCRIBE_BY_TAG_PENDING
+    | typeof ACTION_REMOVE;

--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -547,8 +547,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             subscription.onSubscribe();
@@ -1796,8 +1795,7 @@ describe('openapi StreamingSubscription', () => {
                     'servicePath',
                     'src/test/resource',
                     args,
-                    createdSpy,
-                    { onUpdate: updateSpy },
+                    { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
                 );
                 subscription.onSubscribe();
 
@@ -1844,8 +1842,7 @@ describe('openapi StreamingSubscription', () => {
                     'servicePath',
                     'src/test/resource',
                     args,
-                    createdSpy,
-                    { onUpdate: updateSpy },
+                    { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
                 );
                 subscription.onSubscribe();
 
@@ -1895,8 +1892,7 @@ describe('openapi StreamingSubscription', () => {
                     'servicePath',
                     'src/test/resource',
                     args,
-                    createdSpy,
-                    { onUpdate: updateSpy },
+                    { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
                 );
                 subscription.onSubscribe();
 
@@ -1981,8 +1977,7 @@ describe('openapi StreamingSubscription', () => {
                     'servicePath',
                     'src/test/resource',
                     args,
-                    createdSpy,
-                    { onUpdate: updateSpy },
+                    { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
                 );
                 subscription.onSubscribe();
 

--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -29,6 +29,7 @@ function wait() {
 describe('openapi StreamingSubscription', () => {
     let transport: any;
     let updateSpy: jest.Mock;
+    let readyToRemoveSpy: jest.Mock;
     let createdSpy: jest.Mock;
     let errorSpy: jest.Mock;
     let authManager: { getAuth: jest.Mock };
@@ -46,6 +47,7 @@ describe('openapi StreamingSubscription', () => {
         ParserFacade.clearParsers();
         transport = mockTransport();
         updateSpy = jest.fn().mockName('update');
+        readyToRemoveSpy = jest.fn().mockName('readyToRemove');
         createdSpy = jest.fn().mockName('create');
         errorSpy = jest.fn().mockName('error');
         networkErrorSpy = jest.fn().mockName('networkEror');
@@ -162,7 +164,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                undefined,
                 { headers: { Header: 'header' } },
             );
             subscription.onSubscribe();
@@ -203,7 +204,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                undefined,
                 { headers },
             );
 
@@ -246,8 +246,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -270,8 +269,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -293,7 +291,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
                 { onError: errorSpy },
             );
             subscription.onSubscribe();
@@ -320,7 +317,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'test/resource',
                 { Format: 'application/x-protobuf' },
-                createdSpy,
                 { onError: errorSpy },
             );
             subscription.onSubscribe();
@@ -351,8 +347,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -386,8 +381,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
             sendInitialResponse({ Snapshot: { Data: [] } });
@@ -482,8 +476,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -514,8 +507,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             subscription.onStreamingData({
@@ -579,8 +571,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             subscription.onSubscribe();
@@ -604,8 +595,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             subscription.onSubscribe();
@@ -624,8 +614,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onConnectionUnavailable();
             subscription.onSubscribe();
@@ -639,8 +628,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -667,8 +655,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
             subscription.onConnectionUnavailable();
@@ -694,8 +681,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
             expect(transport.post.mock.calls.length).toEqual(1);
@@ -730,8 +716,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
             expect(transport.post.mock.calls.length).toEqual(1);
@@ -765,7 +750,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
                 {
                     onUpdate: updateSpy,
                     onError: errorSpy,
@@ -802,7 +786,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
                 {
                     onUpdate: updateSpy,
                     onError: errorSpy,
@@ -833,7 +816,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
                 {
                     onUpdate: updateSpy,
                     onError: errorSpy,
@@ -864,7 +846,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
                 {
                     onUpdate: updateSpy,
                     onError: errorSpy,
@@ -895,7 +876,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
                 {
                     onUpdate: updateSpy,
                     onError: errorSpy,
@@ -937,6 +917,32 @@ describe('openapi StreamingSubscription', () => {
         });
     });
 
+    describe('remove', () => {
+        it('should call onSubscriptionReadyToRemove', (done) => {
+            const subscription = new Subscription(
+                '123',
+                transport,
+                'servicePath',
+                'src/test/resource',
+                {},
+                {
+                    onUpdate: updateSpy,
+                    onSubscriptionCreated: createdSpy,
+                    onSubscriptionReadyToRemove: readyToRemoveSpy,
+                },
+            );
+
+            subscription.onRemove();
+
+            setTimeout(() => {
+                // it does invoke onSubscriptionReadyToRemove callback
+                expect(readyToRemoveSpy.mock.calls.length).toEqual(1);
+                // it does invoke onSubscriptionReadyToRemove callback with reference to subscription
+                expect(readyToRemoveSpy.mock.calls[0][0]).toEqual(subscription);
+                done();
+            });
+        });
+    });
     describe('subscribe/unsubscribe queuing', () => {
         it('ignores multiple commands when already in the right state', async () => {
             const subscription = new Subscription(
@@ -945,8 +951,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             const logError = jest.spyOn(log, 'error');
@@ -1019,8 +1024,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             const logError = jest.spyOn(log, 'error');
@@ -1047,8 +1051,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             subscription.onSubscribe();
@@ -1072,8 +1075,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             jest.spyOn(log, 'error');
@@ -1112,8 +1114,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             expect(subscription.timeTillOrphaned(Date.now())).toEqual(Infinity);
@@ -1157,8 +1158,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -1173,8 +1173,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -1194,8 +1193,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -1231,8 +1229,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -1265,7 +1262,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
             );
 
             subscription.reset(true); // reset before subscribed
@@ -1309,7 +1305,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
             );
 
             subscription.reset(true); // reset before subscribed
@@ -1352,7 +1347,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
             );
 
             expect(transport.post.mock.calls.length).toEqual(0);
@@ -1400,8 +1394,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             subscription.onSubscribe();
@@ -1474,8 +1467,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             subscription.onSubscribe();
@@ -1540,8 +1532,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             subscription.onSubscribe();
@@ -1581,8 +1572,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             subscription.onSubscribe();
@@ -1623,8 +1613,7 @@ describe('openapi StreamingSubscription', () => {
                     'servicePath',
                     'src/test/resource',
                     {},
-                    createdSpy,
-                    { onUpdate: updateSpy },
+                    { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
                 );
 
                 subscription.reset(true);
@@ -1654,8 +1643,7 @@ describe('openapi StreamingSubscription', () => {
                     'servicePath',
                     'src/test/resource',
                     {},
-                    createdSpy,
-                    { onUpdate: updateSpy },
+                    { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
                 );
 
                 subscription.reset(true);
@@ -1716,8 +1704,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 args,
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -1761,8 +1748,8 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 args,
-                createdSpy,
-                { onUpdate: updateSpy },
+
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -2093,8 +2080,8 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 args,
-                createdSpy,
-                { onUpdate: updateSpy },
+
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -2122,8 +2109,8 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 args,
-                createdSpy,
-                { onUpdate: updateSpy },
+
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -2152,8 +2139,8 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 args,
-                createdSpy,
-                { onUpdate: updateSpy },
+
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
             subscription.onSubscribe();
 
@@ -2190,8 +2177,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             const initialArgs = { initialArgs: 'initialArgs' };
@@ -2230,8 +2216,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             const initialArgs = { initialArgs: 'initialArgs' };
@@ -2275,8 +2260,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             const initialArgs = { initialArgs: 'initialArgs' };
@@ -2305,8 +2289,7 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
-                { onUpdate: updateSpy },
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
             );
 
             const initialArgs = { initialArgs: 'initialArgs' };
@@ -2356,7 +2339,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
             );
             subscription.onSubscribe();
 
@@ -2403,7 +2385,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
             );
             subscription.onSubscribe();
 
@@ -2450,7 +2431,6 @@ describe('openapi StreamingSubscription', () => {
                 'servicePath',
                 'src/test/resource',
                 {},
-                createdSpy,
             );
             subscription.onSubscribe();
 

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -7,6 +7,7 @@ import {
     ACTION_MODIFY_PATCH,
     ACTION_UNSUBSCRIBE_BY_TAG_PENDING,
     ACTION_MODIFY_REPLACE,
+    ACTION_REMOVE,
 } from './subscription-actions';
 import SubscriptionQueue from './subscription-queue';
 import type { QueuedItem } from './subscription-queue';
@@ -59,6 +60,17 @@ export interface StreamingOptions {
      * A callback function that is invoked on network error.
      */
     onNetworkError?: () => void;
+}
+
+export interface InternalStreamingOptions {
+    /**
+     * A callback function that is invoked on network error.
+     */
+    onNetworkError: () => void;
+    /**
+     * A callback function that is invoked when the subscription is ready to be removed.
+     */
+    onSubscriptionReadyToRemove: () => void;
 }
 
 export interface SubscriptionArgs {
@@ -177,6 +189,7 @@ class Subscription {
      * The action queue.
      */
     queue = new SubscriptionQueue();
+    onSubscriptionReadyToRemove: () => void;
     parser;
     onStateChangedCallbacks: Array<(state: SubscriptionState) => void> = [];
     transport: ITransport;
@@ -207,8 +220,8 @@ class Subscription {
         servicePath: string,
         url: string,
         subscriptionArgs: SubscriptionArgs,
-        onSubscriptionCreated?: () => void,
-        options: StreamingOptions = {},
+        onSubscriptionCreated: () => void,
+        options: StreamingOptions & InternalStreamingOptions,
     ) {
         this.streamingContextId = streamingContextId;
 
@@ -235,6 +248,7 @@ class Subscription {
         this.onQueueEmpty = options.onQueueEmpty;
         this.headers = options.headers && extend({}, options.headers);
         this.onNetworkError = options.onNetworkError;
+        this.onSubscriptionReadyToRemove = options.onSubscriptionReadyToRemove;
 
         if (!this.subscriptionData.RefreshRate) {
             this.subscriptionData.RefreshRate = DEFAULT_REFRESH_RATE_MS;
@@ -474,6 +488,24 @@ class Subscription {
         const { action, args } = queuedAction;
 
         switch (action) {
+            case ACTION_REMOVE:
+                switch (this.currentState) {
+                    case this.STATE_SUBSCRIBED:
+                        log.error(
+                            LOG_AREA,
+                            'Unanticipated state in performAction Remove',
+                            {
+                                state: this.currentState,
+                                action,
+                                url: this.url,
+                                servicePath: this.servicePath,
+                            },
+                        );
+                }
+                this.dispose();
+                this.onSubscriptionReadyToRemove();
+                break;
+
             case ACTION_SUBSCRIBE:
                 switch (this.currentState) {
                     case this.STATE_SUBSCRIBED:
@@ -1112,6 +1144,17 @@ class Subscription {
         }
 
         this.tryPerformAction(ACTION_SUBSCRIBE, { replace });
+    }
+
+    /**
+     * Remove the subscription once it has finished processing previous actions
+     */
+    onRemove() {
+        if (this.isDisposed) {
+            throw new Error('Removing a disposed subscription');
+        }
+
+        this.tryPerformAction(ACTION_REMOVE);
     }
 
     /**


### PR DESCRIPTION
In a connection outage if disposeSubscription is called, then the subscription does nothing as it is in a connection unavailable state, then it is removed from the list of subscriptions, so it is never made available and unsubscribe is never called, leading to hanging subscriptions.

Solution - make a new action for removing so that it is only removed once the existing queue is clear.