### PR TITLE
Do not remove nanoseconds when parsing Timestamp

### DIFF
--- a/src/openapi/streaming/parser/parser-protobuf.spec.ts
+++ b/src/openapi/streaming/parser/parser-protobuf.spec.ts
@@ -261,14 +261,14 @@ describe('Parser Protobuf', () => {
                         BuySell: 'buy',
                         AccountId: 'ALGO-USD',
                         Price: 1.3423,
-                        OrderTime: '2017-11-08T11:41:44.000Z',
+                        OrderTime: '2017-11-08T11:41:44.000000000Z',
                     },
                     {
                         OrderId: 'xwc456',
                         BuySell: 'sell',
                         AccountId: 'EUR',
                         Price: 9.123,
-                        OrderTime: '2017-11-08T11:41:44.783Z',
+                        OrderTime: '2017-11-08T11:41:44.783859279Z',
                     },
                 ]),
             );

--- a/src/openapi/streaming/parser/wrappers/protobuf-wrappers.ts
+++ b/src/openapi/streaming/parser/wrappers/protobuf-wrappers.ts
@@ -23,7 +23,12 @@ export default {
                             Math.floor(Number(nanos) / 1000000),
                     );
 
-                    return date.toJSON();
+                    return date
+                        .toISOString()
+                        .replace(
+                            'Z',
+                            `${(nanos % 1000000).toString().padStart(6, '0')}Z`,
+                        );
                 },
             };
         }

--- a/src/test/mocks/proto-price.ts
+++ b/src/test/mocks/proto-price.ts
@@ -291,25 +291,25 @@ export const decodedObjectMessage = {
         dma: true,
         est_price_buy: 8,
         est_price_sell: 9,
-        expiry_date: '2017-11-08T11:41:44.000Z',
+        expiry_date: '2017-11-08T11:41:44.000000000Z',
         is_market_open: true,
         lower_barrier: 1.3213,
         mid_forward_price: 1.1123,
         mid_spot_price: 1.3231,
         mid_yield: 1.2323,
-        notice_date: '2017-11-08T11:41:44.000Z',
+        notice_date: '2017-11-08T11:41:44.000000000Z',
         open_interest: 0.123,
         paid_cfd_interest: 0.321,
         received_cfd_interest: 0.11112,
         short_trade_disabled: true,
         spot_ask: 1.11,
         spot_bid: 1.32,
-        spot_date: '2017-11-08T11:41:44.000Z',
+        spot_date: '2017-11-08T11:41:44.000000000Z',
         strike_price: 1.3212,
         upper_barrier: 1.3331,
-        value_date: '2017-11-08T11:41:44.000Z',
+        value_date: '2017-11-08T11:41:44.000000000Z',
     },
-    last_updated: '2017-11-08T11:41:44.000Z',
+    last_updated: '2017-11-08T11:41:44.000000000Z',
     margin_impact: {
         impact_buy: 1.32,
         impact_sell: 2.13,
@@ -410,7 +410,7 @@ export const encodedMessage =
     'CghGeE9wdGlvbhI/CUw3iUFgpSRAEfgZFw6EpCZAGQAAAAAAQI9AIdeGinH+JlQ/KSUGgZVDi9Q/MXsUrkfhetQ/OSlcj8L1KLw/GkgJAAAAAAAA8D8RAAAAAACYn0AZAAAAAAAACEAhAAAAAABwn0ApAAAAAAAAFEAxAAAAAACMn0A5AAAAAAAAHEBBAAAAAAAAIEAi1QEJAAAAAAAA8D8RAAAAAAAAAEAZAAAAAAAACEAhAAAAAAAAEEApAAAAAAAAFEAwATgBQQAAAAAAACBASQAAAAAAACJAUgYI+NqL0AVYAWHcRgN4CyT1P2nrc7UV+8vxP3HPZtXnaiv1P3nWxW00gLfzP4IBBgj42ovQBYkBsHJoke18vz+RASUGgZVDi9Q/mQEYeO49XHK8P6ABAakBw/UoXI/C8T+xAR+F61G4HvU/ugEGCPjai9AFwQFrmnecoiP1P8kB+MJkqmBU9T/SAQYI+NqL0AUqBgj42ovQBTIkCR+F61G4HvU/EQrXo3A9CgFAGcP1KFyPwvE/IYlBYOXQIvU/OnIKEIlBYOXQIvU/w/UoXI/C8T8SEPYoXI/C9QhA4XoUrkfhCEAaEAAAAAAAQI9AAAAAAABAn0AiECPb+X5qvPY/iUFg5dAi9T8qELx0kxgEVvg/nu+nxks39z8yEAAAAAAAQJ9AAAAAAADAkkA4IEBISAFCJAmuR+F6FK7zPxHsUbgehevxPxkAAAAAAAAmQCG4HoXrUbi+P0oGTkFTREFRUksIzgkRrkfhehSu8z8Zw/UoXI/C8T8gFyoEMTIzNTFmZmZmZmbyPzoHYXNrdHlwZUIHYmlkdHlwZUoLMTIzMTNjZGFkYWRSBGlkbGVYrGA=';
 
 export const encodedMessageOrder =
-    'Gi0iCEFMR08tVVNEUgNidXn6AQZhYmMxMjOKAggI+NqL0AUQAJECmbuWkA969T8aLSIDRVVSUgRzZWxs+gEGeHdjNDU2igIMCPjai9AFEMDDrvUCkQLl0CLb+T4iQA==';
+    'Gi0iCEFMR08tVVNEUgNidXn6AQZhYmMxMjOKAggI+NqL0AUQAJECmbuWkA969T8aLSIDRVVSUgRzZWxs+gEGeHdjNDU2igIMCPjai9AFEM/84vUCkQLl0CLb+T4iQA==';
 
 export const orderObjectMessage = {
     Collection: [
@@ -431,7 +431,7 @@ export const orderObjectMessage = {
             Price: 9.123,
             OrderTime: {
                 seconds: '1510141304',
-                nanos: '783000000',
+                nanos: '783859279',
             },
         },
     ],


### PR DESCRIPTION
Currently {seconds: 1634805065 nanos: 23369000} is converted to converts it to "2021-10-21T08:31:05.023Z". Nanoseconds precision is truncated to milliseconds. Nanoseconds precision is needed to use AcquireTime as a parameter to markettrades API.

After change Timestamp will be parsed to "2021-10-21T08:31:05.023869000Z" which is valid ISO 8601 format and do not affect value of native Date or moment based on higher precision format.

Closes #581