### PR TITLE
#1448366 reset all subscription is missing message

### DIFF
--- a/src/openapi/streaming/connection/connection.ts
+++ b/src/openapi/streaming/connection/connection.ts
@@ -66,6 +66,7 @@ class Connection {
     stateChangedCallback = NOOP;
     receiveCallback: ReceiveCallback = NOOP;
     connectionSlowCallback = NOOP;
+    subscriptionResetCallback = NOOP;
     authToken: string | null = null;
     authExpiry: number | null | undefined = null;
     contextId: string | null = null;
@@ -163,6 +164,10 @@ class Connection {
         this.transport.setStateChangedCallback(this.stateChangedCallback);
         this.transport.setUnauthorizedCallback(this.unauthorizedCallback);
         this.transport.setConnectionSlowCallback(this.connectionSlowCallback);
+
+        if (typeof this.transport.setSubscriptionResetCallback === 'function') {
+            this.transport.setSubscriptionResetCallback(this.subscriptionResetCallback);
+        }
 
         if (this.state === STATE_STARTED) {
             this.transport.updateQuery(
@@ -266,6 +271,19 @@ class Connection {
             );
             this.transport.setConnectionSlowCallback(
                 this.connectionSlowCallback,
+            );
+        }
+    }
+
+    setSubscriptionResetCallback(callback: () => void) {
+        if (this.transport && typeof this.transport.setSubscriptionResetCallback === 'function') {
+            this.setSubscriptionResetCallback = this.ensureValidState.bind(
+                this,
+                callback,
+                'setSubscriptionResetCallback',
+            );
+            this.transport.setSubscriptionResetCallback(
+                this.subscriptionResetCallback,
             );
         }
     }

--- a/src/openapi/streaming/connection/connection.ts
+++ b/src/openapi/streaming/connection/connection.ts
@@ -166,7 +166,9 @@ class Connection {
         this.transport.setConnectionSlowCallback(this.connectionSlowCallback);
 
         if (typeof this.transport.setSubscriptionResetCallback === 'function') {
-            this.transport.setSubscriptionResetCallback(this.subscriptionResetCallback);
+            this.transport.setSubscriptionResetCallback(
+                this.subscriptionResetCallback,
+            );
         }
 
         if (this.state === STATE_STARTED) {
@@ -276,7 +278,10 @@ class Connection {
     }
 
     setSubscriptionResetCallback(callback: () => void) {
-        if (this.transport && typeof this.transport.setSubscriptionResetCallback === 'function') {
+        if (
+            this.transport &&
+            typeof this.transport.setSubscriptionResetCallback === 'function'
+        ) {
             this.setSubscriptionResetCallback = this.ensureValidState.bind(
                 this,
                 callback,

--- a/src/openapi/streaming/connection/transport/signalr-core-transport.spec.ts
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.spec.ts
@@ -589,13 +589,16 @@ describe('openapi SignalR core Transport', () => {
         const messageId = 10;
         let transport: any;
         let startPromise: Promise<any>;
-        const spyOnSubscriptionResetCallbak = jest.fn()
-        .mockName('subscription reset callback on missing message id');
+        const spyOnSubscriptionResetCallbak = jest
+            .fn()
+            .mockName('subscription reset callback on missing message id');
 
         beforeEach(() => {
             transport = new SignalrCoreTransport(BASE_URL);
             transport.setStateChangedCallback(spyOnStateChangedCallback);
-            transport.setSubscriptionResetCallback(spyOnSubscriptionResetCallbak);
+            transport.setSubscriptionResetCallback(
+                spyOnSubscriptionResetCallbak,
+            );
             transport.updateQuery(
                 authprovider.getToken(),
                 CONTEXT_ID,

--- a/src/openapi/streaming/connection/transport/signalr-core-transport.spec.ts
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.spec.ts
@@ -589,10 +589,13 @@ describe('openapi SignalR core Transport', () => {
         const messageId = 10;
         let transport: any;
         let startPromise: Promise<any>;
+        const spyOnSubscriptionResetCallbak = jest.fn()
+        .mockName('subscription reset callback on missing message id');
 
         beforeEach(() => {
             transport = new SignalrCoreTransport(BASE_URL);
             transport.setStateChangedCallback(spyOnStateChangedCallback);
+            transport.setSubscriptionResetCallback(spyOnSubscriptionResetCallbak);
             transport.updateQuery(
                 authprovider.getToken(),
                 CONTEXT_ID,
@@ -624,7 +627,7 @@ describe('openapi SignalR core Transport', () => {
                 mockReconnect();
                 tick(10);
 
-                const newMessageId = 23;
+                const newMessageId = 11;
                 subscribeNextHandler({
                     PayloadFormat: 1,
                     Payload: window.btoa('{ "a": 32 }'),
@@ -639,6 +642,28 @@ describe('openapi SignalR core Transport', () => {
 
                 done();
             });
+        });
+
+        it('should call reset all subscriptions if message id is missing', () => {
+            mockReconnecting();
+
+            expect(mockHubConnection.baseUrl).toBe(
+                `${BASE_URL}/streaming?contextId=${CONTEXT_ID}&messageId=${messageId}`,
+            );
+            expect(spyOnStateChangedCallback).toHaveBeenCalledWith(
+                constants.CONNECTION_STATE_RECONNECTING,
+            );
+
+            mockReconnect();
+            tick(10);
+
+            const newMessageId = 13;
+            subscribeNextHandler({
+                PayloadFormat: 1,
+                Payload: window.btoa('{ "a": 32 }'),
+                MessageId: newMessageId,
+            });
+            expect(spyOnSubscriptionResetCallbak).toBeCalledTimes(1);
         });
 
         it('should create new message stream on reconnection', () => {

--- a/src/openapi/streaming/connection/transport/signalr-core-transport.ts
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.ts
@@ -482,6 +482,7 @@ class SignalrCoreTransport implements StreamingTransportInterface {
                             messageId: data.MessageId,
                         },
                     );
+                    data.ResetSubscription = true;
                 }
             }
 

--- a/src/openapi/streaming/connection/types.ts
+++ b/src/openapi/streaming/connection/types.ts
@@ -49,6 +49,8 @@ export interface StreamingTransportInterface {
     setUnauthorizedCallback(callback: () => void): void;
 
     setConnectionSlowCallback(callback: () => void): void;
+
+    setSubscriptionResetCallback?(callback: () => void): void;
 }
 
 export type StreamingData =

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -747,7 +747,10 @@ class Streaming extends MicroEmitter<EmittedEvents> {
      * @param subscriptions - subscriptions
      * @param isServerInitiated - (optional) will be false when we do rest due to missing message  Default = true
      */
-    private resetSubscriptions(subscriptions: Subscription[], isServerInitiated = true) {
+    private resetSubscriptions(
+        subscriptions: Subscription[],
+        isServerInitiated = true,
+    ) {
         for (let i = 0; i < subscriptions.length; i++) {
             const subscription = subscriptions[i];
             subscription.reset(isServerInitiated);

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -744,11 +744,13 @@ class Streaming extends MicroEmitter<EmittedEvents> {
 
     /**
      * Resets subscriptions passed
+     * @param subscriptions - subscriptions
+     * @param isServerInitiated - (optional) will be false when we do rest due to missing message  Default = true
      */
-    private resetSubscriptions(subscriptions: Subscription[]) {
+    private resetSubscriptions(subscriptions: Subscription[], isServerInitiated = true) {
         for (let i = 0; i < subscriptions.length; i++) {
             const subscription = subscriptions[i];
-            subscription.reset(true);
+            subscription.reset(isServerInitiated);
         }
     }
 
@@ -1106,7 +1108,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
     }
 
     private onSubscriptionReset() {
-        this.resetSubscriptions(this.subscriptions);
+        this.resetSubscriptions(this.subscriptions, false);
     }
 
     /**

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -558,8 +558,11 @@ class Streaming extends MicroEmitter<EmittedEvents> {
         if (!Array.isArray(updates)) {
             updates = [updates];
         }
-
         for (const update of updates) {
+            if (update.ResetSubscription) {
+                this.resetSubscriptions(this.subscriptions.slice(0));
+                return;
+            }
             this.contextMessageCount++;
             this.processUpdate(update);
         }

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -281,7 +281,9 @@ class Streaming extends MicroEmitter<EmittedEvents> {
         this.connection.setConnectionSlowCallback(
             this.onConnectionSlow.bind(this),
         );
-
+        this.connection.setSubscriptionResetCallback(
+            this.onSubscriptionReset.bind(this),
+        );
         // start the connection process
         this.connect();
     }
@@ -559,10 +561,6 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             updates = [updates];
         }
         for (const update of updates) {
-            if (update.ResetSubscription) {
-                this.resetSubscriptions(this.subscriptions.slice(0));
-                return;
-            }
             this.contextMessageCount++;
             this.processUpdate(update);
         }
@@ -1105,6 +1103,10 @@ class Streaming extends MicroEmitter<EmittedEvents> {
 
     private onSubscribeNetworkError() {
         this.connection.onSubscribeNetworkError();
+    }
+
+    private onSubscriptionReset() {
+        this.resetSubscriptions(this.subscriptions);
     }
 
     /**

--- a/src/openapi/streaming/types.ts
+++ b/src/openapi/streaming/types.ts
@@ -42,6 +42,7 @@ export interface StreamingMessage<T = unknown, R = string> {
     Data: T;
     Heartbeats?: Heartbeats[];
     TargetReferenceIds?: string[];
+    ResetSubscription?: boolean;
 }
 
 type StreamingControlMessage<T = StreamingData, R = string> = StreamingMessage<

--- a/src/openapi/streaming/types.ts
+++ b/src/openapi/streaming/types.ts
@@ -42,7 +42,6 @@ export interface StreamingMessage<T = unknown, R = string> {
     Data: T;
     Heartbeats?: Heartbeats[];
     TargetReferenceIds?: string[];
-    ResetSubscription?: boolean;
 }
 
 type StreamingControlMessage<T = StreamingData, R = string> = StreamingMessage<


### PR DESCRIPTION
BUG 1448366 -  Reset all subscriptions when we get a missing message id, initial logic to review