### PR TITLE
Make streaming error log a warning

### DIFF
--- a/src/openapi/streaming/connection/transport/signalr-core-transport.ts
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.ts
@@ -334,7 +334,7 @@ class SignalrCoreTransport implements StreamingTransportInterface {
                 }
             })
             .catch((error) => {
-                log.error(
+                log.warn(
                     LOG_AREA,
                     'Error occurred while connecting to streaming service',
                     {


### PR DESCRIPTION
This error occurs when there is a network error, so making it a warning rather than a error.