### PR TITLE
Prevent a unhandled rejection and add a buffer for network retry

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
-### v10.6.3
+### v10.6.4
+- Do not immediately retry ws auth after a network error
 
+### v10.6.3
 - Reset messages when we get missing messages on the streaming messages
 
 ### v10.6.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.6.3",
+    "version": "10.6.4",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/streaming/connection/transport/websocket-transport.spec.ts
+++ b/src/openapi/streaming/connection/transport/websocket-transport.spec.ts
@@ -139,9 +139,9 @@ describe('openapi WebSocket Transport', () => {
             fetchMock.mockClear();
 
             fetchMock.reject(new Error('network error'));
-            tick(1);
 
             setTimeout(() => {
+                tick(300);
                 expect(fetchMock).toBeCalledTimes(1);
                 expect(fetchMock).toBeCalledWith(
                     'testUrl/streamingws/authorize?contextId=0000000000',

--- a/src/openapi/streaming/connection/transport/websocket-transport.ts
+++ b/src/openapi/streaming/connection/transport/websocket-transport.ts
@@ -575,7 +575,7 @@ class WebsocketTransport implements StreamingTransportInterface {
                     );
                 }
 
-                log.error(LOG_AREA, 'Authorization failed', error);
+                log.warn(LOG_AREA, 'Authorization failed', error);
                 this.handleFailure();
                 return Promise.reject(
                     new Error('Failed websocket-transport authorize'),


### PR DESCRIPTION
We saw several thousand unhandled rejections occur when a network error was occurring trying to authorize. Whilst not a problem, this change aims to reduce the amount of noise we get when this happens.