### PR TITLE
Remove streaming heartbeat flag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### 10.8.0
+ - Remove streaming heartbeat flag and make it always present
+
 ### v10.7.1
 - Fix a bug where removing a subscription that is not unsubscribed may prevent the subscription being unsubscribed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.7.1",
+    "version": "10.8.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "openapi-clientlib",
-            "version": "10.7.1",
+            "version": "10.8.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@babel/core": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.7.1",
+    "version": "10.8.0",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/streaming/connection/transport/websocket-transport.spec.ts
+++ b/src/openapi/streaming/connection/transport/websocket-transport.spec.ts
@@ -72,7 +72,7 @@ describe('openapi WebSocket Transport', () => {
                 expect(spyOnStartCallback).toBeCalledTimes(1);
                 expect(global.WebSocket).toBeCalledTimes(1);
                 expect(global.WebSocket).toBeCalledWith(
-                    'testUrl/streamingws/connect?contextId=0000000000&Authorization=TOKEN',
+                    'testUrl/streamingws/connect?contextId=0000000000&Authorization=TOKEN&sendHeartbeats=true',
                 );
 
                 done();
@@ -95,7 +95,7 @@ describe('openapi WebSocket Transport', () => {
             transport.authorizePromise?.then(() => {
                 expect(spyOnStartCallback).toBeCalledTimes(1);
                 expect(global.WebSocket).toBeCalledWith(
-                    'testUrl/streamingws/connect?contextId=0000000000&Authorization=TOKEN',
+                    'testUrl/streamingws/connect?contextId=0000000000&Authorization=TOKEN&sendHeartbeats=true',
                 );
 
                 // simulate handshake failure by not calling onopen first
@@ -115,7 +115,7 @@ describe('openapi WebSocket Transport', () => {
 
             transport.updateQuery(AUTH_TOKEN, CONTEXT_ID);
             expect(transport.getQuery()).toBe(
-                '?contextId=0000000000&Authorization=TOKEN',
+                '?contextId=0000000000&Authorization=TOKEN&sendHeartbeats=true',
             );
         });
     });
@@ -663,7 +663,7 @@ describe('openapi WebSocket Transport', () => {
                     ]);
 
                     expect(global.WebSocket).toBeCalledWith(
-                        'testUrl/streamingws/connect?contextId=0000000000&Authorization=NEW-TOKEN',
+                        'testUrl/streamingws/connect?contextId=0000000000&Authorization=NEW-TOKEN&sendHeartbeats=true',
                     );
 
                     done();

--- a/src/openapi/streaming/connection/transport/websocket-transport.ts
+++ b/src/openapi/streaming/connection/transport/websocket-transport.ts
@@ -94,7 +94,6 @@ class WebsocketTransport implements StreamingTransportInterface {
     startedCallback = NOOP;
     unauthorizedCallback = NOOP;
     utf8Decoder!: TextDecoder;
-    isWebsocketStreamingHeartBeatEnabled = false;
     inactivityFinderRunning: boolean;
     inactivityFinderNextUpdateTimeoutId: number | null = null;
 
@@ -138,9 +137,7 @@ class WebsocketTransport implements StreamingTransportInterface {
 
             log.debug(LOG_AREA, 'Socket opened');
             this.stateChangedCallback(constants.CONNECTION_STATE_CONNECTED);
-            if (this.isWebsocketStreamingHeartBeatEnabled) {
-                this.startInactivityFinder();
-            }
+            this.startInactivityFinder();
         }
     };
 
@@ -326,13 +323,9 @@ class WebsocketTransport implements StreamingTransportInterface {
 
     private createSocket() {
         try {
-            let url = this.normalizeWebSocketUrl(
+            const url = this.normalizeWebSocketUrl(
                 `${this.connectionUrl}${this.query}`,
             );
-
-            if (this.isWebsocketStreamingHeartBeatEnabled) {
-                url += '&sendHeartbeats=true';
-            }
 
             log.debug(LOG_AREA, 'Creating WebSocket connection', { url });
             const socket = new WebSocket(url);
@@ -586,10 +579,6 @@ class WebsocketTransport implements StreamingTransportInterface {
     }
     start(_options?: ConnectionOptions, callback?: () => void) {
         this.startedCallback = callback || NOOP;
-        if (_options && _options.isWebsocketStreamingHeartBeatEnabled) {
-            // if set we will recieve _connectionheartbeat after 2 seconds of inactivity on a streaming connection
-            this.isWebsocketStreamingHeartBeatEnabled = true;
-        }
         if (!this.isSupported()) {
             log.error(LOG_AREA, 'WebSocket Transport is not supported');
 
@@ -661,9 +650,10 @@ class WebsocketTransport implements StreamingTransportInterface {
         if (contextId !== this.contextId) {
             this.lastMessageId = null;
         }
+        // sendHeartbeats=true server sends _connectionheartbeat after 2 seconds of inactivity on a streaming connection
         let query = `?contextId=${encodeURIComponent(
             contextId,
-        )}&Authorization=${encodeURIComponent(authToken)}`;
+        )}&Authorization=${encodeURIComponent(authToken)}&sendHeartbeats=true`;
 
         if (this.lastMessageId != null) {
             query += `&messageid=${this.lastMessageId}`;

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -226,7 +226,6 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             connectRetryDelayLevels,
             parserEngines,
             parsers,
-            isWebsocketStreamingHeartBeatEnabled,
             clearSubscriptionsInDispose,
         } = options;
 
@@ -240,7 +239,6 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             // Streaming service relays message payload received from publishers as it is, which could be protobuf encoded.
             // This protocol is used to serialize the message envelope rather than the payload
             messageSerializationProtocol,
-            isWebsocketStreamingHeartBeatEnabled,
         };
 
         if (typeof connectRetryDelay === 'number') {


### PR DESCRIPTION
- Remove streaming heartbeat flag, making it present for all suitable requests.
- Bump version

SaxoTrader PR: #155503 

This is based on Himashu's PR: https://github.com/SaxoBank/openapi-clientlib-js/pull/538
Created a new one as I didn't have access to his repo to rebase on the newest master.