### PR TITLE
assume no content if 204

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### v10.8.6
+
+-   Assume 204 response has no content
+
 ### v10.8.5
 
 -   Remove unnecessary warning log

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.8.5",
+    "version": "10.8.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "openapi-clientlib",
-            "version": "10.8.5",
+            "version": "10.8.6",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@babel/core": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.8.5",
+    "version": "10.8.6",
     "engines": {
         "node": ">=14"
     },

--- a/src/utils/fetch.spec.ts
+++ b/src/utils/fetch.spec.ts
@@ -360,6 +360,41 @@ describe('utils fetch', () => {
                 `);
     });
 
+    it('resolves if status 204', async () => {
+        // @ts-ignore
+        const result = {
+            headers: {
+                get() {
+                    return undefined;
+                },
+            },
+            status: 204,
+            text: () => {
+                return Promise.reject('Should not call text');
+            },
+        };
+
+        const promise = convertFetchSuccess(
+            'url',
+            'body',
+            0,
+            // @ts-ignore
+            result,
+        );
+
+        await expect(promise).resolves.toMatchInlineSnapshot(`
+                    Object {
+                      "headers": Object {
+                        "get": [Function],
+                      },
+                      "response": undefined,
+                      "size": 0,
+                      "status": 204,
+                      "url": "url",
+                    }
+                `);
+    });
+
     // we would like to remove this test case in the future
     it('resolves if no content type and text rejects', async () => {
         // @ts-ignore

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -228,7 +228,7 @@ export function convertFetchSuccess(
                 };
             },
         );
-    } else if (contentLength === '0') {
+    } else if (contentLength === '0' || status === 204) {
         convertedPromise = Promise.resolve({
             response: undefined,
             status,


### PR DESCRIPTION
We have a number of 204 responses where we log a warning about no content type.

Since 204 means no content, we can assume we do not need to process the content.