### PR TITLE
Fix potential subscription error handling issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### v10.8.8
+
+-  Handle subscription errors on replace better
+
+
 ### v10.8.7
 
 -  Reduce some error logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.8.7",
+    "version": "10.8.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "openapi-clientlib",
-            "version": "10.8.7",
+            "version": "10.8.8",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@babel/core": "7.16.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.8.7",
+    "version": "10.8.8",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -2419,13 +2419,17 @@ describe('openapi StreamingSubscription', () => {
             );
         });
 
-        it('handles modify replace error', async () => {
+        it.only('handles modify replace error', async () => {
+            const onError = jest.fn();
             const subscription = new Subscription(
                 '123',
                 transport,
                 'servicePath',
                 'src/test/resource',
                 {},
+                {
+                    onError,
+                },
             );
             subscription.onSubscribe();
 
@@ -2446,6 +2450,7 @@ describe('openapi StreamingSubscription', () => {
             expect(subscription.currentState).toBe(
                 subscription.STATE_REPLACE_REQUESTED,
             );
+            expect(onError).not.toBeCalled();
 
             transport.postReject({
                 status: '500',
@@ -2454,8 +2459,9 @@ describe('openapi StreamingSubscription', () => {
 
             await wait();
             expect(subscription.currentState).toBe(
-                subscription.STATE_SUBSCRIBED,
+                subscription.STATE_UNSUBSCRIBED,
             );
+            expect(onError).toBeCalled();
         });
     });
 });

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -716,7 +716,7 @@ class Subscription {
             .catch((error: any) => {
                 log.debug(
                     LOG_AREA,
-                    'Failed to remove duplicate request subscription',
+                    'Failed to remove left over request subscription',
                     error,
                 );
             });
@@ -745,9 +745,11 @@ class Subscription {
         const willUnsubscribe = nextAction && nextAction & ACTION_UNSUBSCRIBE;
         const isReplace = this.currentState === this.STATE_REPLACE_REQUESTED;
 
-        this.setState(
-            isReplace ? this.STATE_SUBSCRIBED : this.STATE_UNSUBSCRIBED,
-        );
+        if (isReplace) {
+            this.cleanUpLeftOverSubscription(referenceId);
+        }
+
+        this.setState(this.STATE_UNSUBSCRIBED);
 
         // if we are a duplicate response, we should unsubscribe now
         const isDupeRequest =


### PR DESCRIPTION
If we keep the state as subscribed when we error then retries (protobuf error / network error) will not happen, they will be ignored as the state will still be subscribed and subscribe on a subscribed state is a no-op.