### PR TITLE
Fix unanticipated state errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### v10.10.4
+
+-   Fix some bugs that can occur with multiple patches and resets that could result in a stalled subscription
+
 ### v10.10.3
 
 -   Added additional logging information

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.10.3",
+    "version": "10.10.4",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/streaming/subscription-actions.ts
+++ b/src/openapi/streaming/subscription-actions.ts
@@ -1,6 +1,5 @@
 export const ACTION_SUBSCRIBE = 0x1 as const;
 export const ACTION_UNSUBSCRIBE = 0x2 as const;
-export const ACTION_MODIFY = 0x4 as const;
 export const ACTION_MODIFY_PATCH = 0x8 as const;
 export const ACTION_MODIFY_REPLACE = 0x10 as const;
 export const ACTION_UNSUBSCRIBE_BY_TAG_PENDING = 0x20 as const;
@@ -9,7 +8,6 @@ export const ACTION_REMOVE = 0x40 as const;
 export type SubscriptionAction =
     | typeof ACTION_SUBSCRIBE
     | typeof ACTION_UNSUBSCRIBE
-    | typeof ACTION_MODIFY
     | typeof ACTION_MODIFY_PATCH
     | typeof ACTION_MODIFY_REPLACE
     | typeof ACTION_UNSUBSCRIBE_BY_TAG_PENDING

--- a/src/openapi/streaming/subscription-queue.ts
+++ b/src/openapi/streaming/subscription-queue.ts
@@ -142,6 +142,24 @@ class SubscriptionQueue {
     }
 
     /**
+     * Looks to see if the end state after processing actions is to be unsubscribed or not
+     * If the actions are indeterminate (for example, no actions) then it returns the current
+     * state passed as a argument
+     */
+    peekIsSubscribed(isSubscribedNow: boolean): boolean {
+        for (let i = this.items.length - 1; i >= 0; i--) {
+            const action = this.items[i].action;
+            if (action === ACTION_SUBSCRIBE) {
+                return true;
+            }
+            if (action === ACTION_UNSUBSCRIBE) {
+                return false;
+            }
+        }
+        return isSubscribedNow;
+    }
+
+    /**
      * Removes and returns the action from the beginning of a queue.
      * @returns  First action, if queue is not empty. Otherwise undefined.
      */

--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -1415,7 +1415,7 @@ describe('openapi StreamingSubscription', () => {
                     Object {
                       "action": 2,
                       "args": Object {
-                        "force": false,
+                        "force": true,
                       },
                     },
                   ],
@@ -2394,7 +2394,7 @@ describe('openapi StreamingSubscription', () => {
             );
             subscription.reset(true);
             expect(subscription.currentState).toEqual(
-                subscription.STATE_UNSUBSCRIBE_REQUESTED,
+                subscription.STATE_PATCH_REQUESTED,
             );
 
             // patch comes back successful
@@ -2402,9 +2402,17 @@ describe('openapi StreamingSubscription', () => {
                 status: '200',
                 response: '',
             });
-            // delete done at the same time comes back
+
+            await wait();
+
+            expect(subscription.currentState).toEqual(
+                subscription.STATE_UNSUBSCRIBE_REQUESTED,
+            );
+
+            // delete is done and can now be resolved
             transport.deleteResolve({ status: '200', response: '' });
             await wait();
+            // subscribe occurs
             expect(subscription.currentState).toEqual(
                 subscription.STATE_SUBSCRIBE_REQUESTED,
             );
@@ -2439,8 +2447,9 @@ describe('openapi StreamingSubscription', () => {
                 subscription.STATE_PATCH_REQUESTED,
             );
             subscription.reset(true);
+
             expect(subscription.currentState).toEqual(
-                subscription.STATE_UNSUBSCRIBE_REQUESTED,
+                subscription.STATE_PATCH_REQUESTED,
             );
 
             // patch comes back
@@ -2448,6 +2457,13 @@ describe('openapi StreamingSubscription', () => {
                 status: '500',
                 response: 'Subscription no longer exists!',
             });
+
+            await wait();
+
+            expect(subscription.currentState).toEqual(
+                subscription.STATE_UNSUBSCRIBE_REQUESTED,
+            );
+
             // delete done at the same time comes back
             transport.deleteResolve({ status: '200', response: '' });
             await wait();

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -1153,10 +1153,7 @@ class Subscription {
                 // If we were patching we *could* try and ignore the current patch
                 // but that starts getting complicated because the patch callback might change state
                 // if the callback comes back before subscribe changes the reference id.
-
-                // if we have some patches in the queue, we can remove them
-                // as we will be re-subscribing
-                this.queue.clearModifys();
+                // See the PR removing this feature here: https://github.com/SaxoBank/openapi-clientlib-js/pull/747
 
                 // If we are going to unsubscribe as our final action, we shouldn't subscribe
                 // after unsubscribing


### PR DESCRIPTION
When a subscription is reset, if it is waiting for a patch to be processed it has a "optimisation" where it sets the state to subscribed and calls unsubscribe. This then sets the state to unsubscribe requested and subscribe is queued.

However because the state is not transitioning, unsubscribe is not queued, so the queue does not remove patches (the queue will say, adding unsubscribe where patches are queued means the patches are not needed).

In addition the patch request, when it returns, with either a error or a success will, if the reference id hasn't changed (which it probably won't because unsubscribe hasn't come back yet), set the state to subscribed and continue to call the next item in the queue, which might be another patch. The unsubscribe comes back and sets the state to unsubscribed.. Followed by a patch which then triggers the error.

But there are all sorts of things that can go wrong because now the state machine is processing 2 actions at once. The subscribe can happen when the state is subscribed (after a patch) which can result in the subscription not being subscribed, but thinking it is etc.

I've decided to remove and simplify the code to just queue a unsubscribe after the patch comes back. This means I can't unit test the scenario where the problem occurs, because it cannot occur any more (there is already a unit test covering the scenario, it just didn't test events resolving in the opposite order or a bigger queue).

I also noticed that the code to just return on a reset if unsubscribe was peeked could be improved - the unsubscribe that was left was not forced, so it could be removed, which would also end up with us not being subscribed but thinking we are.

Finally I removed ACTION_MODIFY because after removing the code, it was no longer referenced - I believe it should have been deleted back when replace was added.

I hope the new solution is simpler and less error prone.