### PR TITLE
Remove waiting for publisher state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### v10.10.5
+
+-   Fix further bugs that can occur with multiple resets that can result in a stalled subscription
+
 ### v10.10.4
 
 -   Fix some bugs that can occur with multiple patches and resets that could result in a stalled subscription

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.10.4",
+    "version": "10.10.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "openapi-clientlib",
-            "version": "10.10.4",
+            "version": "10.10.5",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@babel/core": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.10.4",
+    "version": "10.10.5",
     "engines": {
         "node": ">=14"
     },


### PR DESCRIPTION
Another error is caused because the waiting for publisher state is set but we might be waiting for a patch to complete, so the state will get overridden with a subscribed state, taking us out of waiting for publisher. We may also do a reset when not needed, but again this is low impact.

Because the code bypasses waiting for publisher when we try and unsubscribe (try perform action), it might have items in the queue, but these are ignored (usually items in the queue must mean transitioning state, meaning we only add to the queue), it means that we process the unsubscribe, but we may have subscribe in the queue, so we do that after the unsubscribe. e.g.

1. waiting for publisher
2. call subscribe
3. call unsubscribe & remove
4. unsubscribe is processed
5. the subscribe is processed
6. the remove is processed

and the end result of that is that we are subscribed when we don't want to be subscribed.

I've fixed this by removing the state entirely. Instead.. if we are still in the same place as when the reset occurs, we do the reset, so it will just be x seconds later than expected.

But we never change the state and we never bypass a transitioning state by doing a action, which should avoid the bug.