### PR TITLE
Fix modify after network error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### v10.10.7
+
+-   Fix an issue if a modify occurs whilst waiting to retry a subscription that failed due to a network issue, then
+    it would just log a error and not attempt a re-subscribe.
+
 ### v10.10.6
 
 -   Fix errors that can occur if a subscription error occurs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.10.6",
+    "version": "10.10.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "openapi-clientlib",
-            "version": "10.10.6",
+            "version": "10.10.7",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@babel/core": "7.18.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.10.6",
+    "version": "10.10.7",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -1211,6 +1211,83 @@ describe('openapi StreamingSubscription', () => {
 
             subscription.onModify();
             tick(5000);
+            await wait();
+            expect(transport.post.mock.calls.length).toEqual(2);
+
+            expect(errorSpy).not.toBeCalled();
+            expect(updateSpy).not.toBeCalled();
+            expect(networkErrorSpy).toBeCalledTimes(1);
+        });
+
+        it('does not retry when a network error occurs subscribing but we afterwards modify replace', async () => {
+            const subscription = new Subscription(
+                '123',
+                transport,
+                'servicePath',
+                'src/test/resource',
+                {},
+                {
+                    onUpdate: updateSpy,
+                    onError: errorSpy,
+                    onNetworkError: networkErrorSpy,
+                },
+            );
+            subscription.onSubscribe();
+            expect(transport.post.mock.calls.length).toEqual(1);
+
+            transport.postReject({ isNetworkError: true });
+
+            await wait();
+            expect(transport.post.mock.calls.length).toEqual(1);
+
+            subscription.onModify(
+                { test: true },
+                {
+                    isReplace: true,
+                    isPatch: false,
+                    patchArgsDelta: { test: true },
+                },
+            );
+            tick(5000);
+            await wait();
+            expect(transport.post.mock.calls.length).toEqual(2);
+
+            expect(errorSpy).not.toBeCalled();
+            expect(updateSpy).not.toBeCalled();
+            expect(networkErrorSpy).toBeCalledTimes(1);
+        });
+
+        it('does not retry when a network error occurs subscribing but we afterwards modify patch', async () => {
+            const subscription = new Subscription(
+                '123',
+                transport,
+                'servicePath',
+                'src/test/resource',
+                {},
+                {
+                    onUpdate: updateSpy,
+                    onError: errorSpy,
+                    onNetworkError: networkErrorSpy,
+                },
+            );
+            subscription.onSubscribe();
+            expect(transport.post.mock.calls.length).toEqual(1);
+
+            transport.postReject({ isNetworkError: true });
+
+            await wait();
+            expect(transport.post.mock.calls.length).toEqual(1);
+
+            subscription.onModify(
+                { test: true },
+                {
+                    isReplace: false,
+                    isPatch: true,
+                    patchArgsDelta: { test: true },
+                },
+            );
+            tick(5000);
+            await wait();
             expect(transport.post.mock.calls.length).toEqual(2);
 
             expect(errorSpy).not.toBeCalled();


### PR DESCRIPTION
Fix an issue if a modify occurs whilst waiting to retry a subscription that failed due to a network issue, then it would just log a error and not attempt a re-subscribe.

I thought this was covered in tests but it only covered the modify that is subscribe/unsubscribe. not replace mode or patch.