### PR TITLE
Fix remove not disabling data update

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### v10.11.1
+
+-  Fix a bug causing data updates from a removed subscription
+
 ### v10.11.0
 
 -   Pass the subscription object back with updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.11.0",
+    "version": "10.11.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "openapi-clientlib",
-            "version": "10.11.0",
+            "version": "10.11.1",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@babel/core": "7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.11.0",
+    "version": "10.11.1",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/streaming/streaming-websocket.spec.ts
+++ b/src/openapi/streaming/streaming-websocket.spec.ts
@@ -805,8 +805,7 @@ describe('openapi Streaming', () => {
             const options = {
                 isPatch: false,
                 isReplace: false,
-                patchArgsDelta: {},
-            };
+            } as const;
             streaming.modify(subscription, args, options);
 
             expect(subscription.onModify.mock.calls.length).toEqual(1);

--- a/src/openapi/streaming/streaming.spec.ts
+++ b/src/openapi/streaming/streaming.spec.ts
@@ -1261,8 +1261,7 @@ describe('openapi Streaming', () => {
             const options = {
                 isPatch: false,
                 isReplace: false,
-                patchArgsDelta: {},
-            };
+            } as const;
             streaming.modify(subscription, args, options);
 
             expect(subscription.onModify.mock.calls.length).toEqual(1);

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -1208,11 +1208,20 @@ class Streaming extends MicroEmitter<EmittedEvents> {
     modify(
         subscription: Subscription,
         args: Record<string, unknown>,
-        options: {
-            isPatch: boolean;
-            isReplace: boolean;
-            patchArgsDelta: Record<string, unknown>;
-        },
+        options:
+            | {
+                  isPatch?: false;
+                  isReplace: true;
+              }
+            | {
+                  isPatch: true;
+                  isReplace?: false;
+                  patchArgsDelta: Record<string, unknown>;
+              }
+            | {
+                  isPatch?: false;
+                  isReplace?: false;
+              },
     ) {
         subscription.onModify(args, options);
     }

--- a/src/openapi/streaming/subscription-queue.ts
+++ b/src/openapi/streaming/subscription-queue.ts
@@ -59,7 +59,11 @@ class SubscriptionQueue {
                 prevItem.args &&
                 !prevItem.args.force
             ) {
-                prevItem.args.force = true;
+                // remove the unsubscribe without force because we are adding with force
+                this.items.splice(-1);
+                // try again so we process the force remove consequences
+                this.enqueue(queuedItem);
+                return;
             }
 
             return;
@@ -74,8 +78,9 @@ class SubscriptionQueue {
             (prevAction === ACTION_SUBSCRIBE &&
                 (action === ACTION_UNSUBSCRIBE ||
                     action === ACTION_UNSUBSCRIBE_BY_TAG_PENDING)) ||
-            // unsubscribing when we need to patch can happen if we are sure the unsubscribe will happen
-            (prevAction === ACTION_MODIFY_PATCH &&
+            // unsubscribing when we need to patch or replace can happen if we are sure the unsubscribe will happen
+            ((prevAction === ACTION_MODIFY_PATCH ||
+                prevAction === ACTION_MODIFY_REPLACE) &&
                 ((action === ACTION_UNSUBSCRIBE && queuedItem.args?.force) ||
                     action === ACTION_UNSUBSCRIBE_BY_TAG_PENDING)) ||
             // We can switch a force unsubscribe for a unsubscribe by tag because there is no logic

--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -365,11 +365,7 @@ describe('openapi StreamingSubscription', () => {
             );
             subscription.onSubscribe();
 
-            const patchArgsDelta = { argsDelta: 'delta' };
-            subscription.onModify(
-                { args: 'test' },
-                { isPatch: false, isReplace: true, patchArgsDelta },
-            );
+            subscription.onModify({ args: 'test' }, { isReplace: true });
 
             expect(subscription.queue.items.length).toEqual(1);
 
@@ -1289,8 +1285,6 @@ describe('openapi StreamingSubscription', () => {
                 { test: true },
                 {
                     isReplace: true,
-                    isPatch: false,
-                    patchArgsDelta: { test: true },
                 },
             );
             tick(5000);
@@ -2562,10 +2556,7 @@ describe('openapi StreamingSubscription', () => {
                 `"2"`,
             );
 
-            subscription.onModify(
-                {},
-                { isReplace: true, isPatch: false, patchArgsDelta: {} },
-            );
+            subscription.onModify({}, { isReplace: true });
 
             await wait();
 
@@ -3515,9 +3506,7 @@ describe('openapi StreamingSubscription', () => {
             const previousReferenceId = subscription.referenceId;
             const newArgs = { newArgs: 'test' };
             subscription.onModify(newArgs, {
-                isPatch: false,
                 isReplace: true,
-                patchArgsDelta: {},
             });
             // subscribed with new arguments
             expect(subscription.subscriptionData.Arguments).toEqual(newArgs);
@@ -3802,10 +3791,7 @@ describe('openapi StreamingSubscription', () => {
                 subscription.STATE_SUBSCRIBED,
             );
 
-            subscription.onModify(
-                { newArgs: 'test' },
-                { isPatch: false, isReplace: true, patchArgsDelta: {} },
-            );
+            subscription.onModify({ newArgs: 'test' }, { isReplace: true });
             expect(subscription.currentState).toBe(
                 subscription.STATE_REPLACE_REQUESTED,
             );
@@ -3847,10 +3833,7 @@ describe('openapi StreamingSubscription', () => {
                 subscription.STATE_SUBSCRIBED,
             );
 
-            subscription.onModify(
-                { newArgs: 'test' },
-                { isPatch: false, isReplace: true, patchArgsDelta: {} },
-            );
+            subscription.onModify({ newArgs: 'test' }, { isReplace: true });
             expect(subscription.currentState).toBe(
                 subscription.STATE_REPLACE_REQUESTED,
             );

--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -698,6 +698,43 @@ describe('openapi StreamingSubscription', () => {
             expect(updateSpy.mock.calls.length).toEqual(0);
         });
 
+        it('ignores snapshot when going to unsubscribe after modify_replace', async () => {
+            const subscription = new Subscription(
+                '123',
+                transport,
+                'servicePath',
+                'src/test/resource',
+                {},
+                { onUpdate: updateSpy, onSubscriptionCreated: createdSpy },
+            );
+
+            subscription.onSubscribe();
+
+            subscription.onModify(
+                { test: true },
+                {
+                    isReplace: true,
+                    isPatch: false,
+                },
+            );
+
+            subscription.onUnsubscribe();
+            subscription.onUnsubscribe(true);
+            subscription.onRemove();
+
+            subscription.onStreamingData({
+                ReferenceId: subscription.referenceId as string,
+                Data: 'foo',
+            });
+
+            const initialResponse = { Snapshot: { Data: [1, 'fish', 3] } };
+            sendInitialResponse(initialResponse);
+
+            await wait();
+
+            expect(updateSpy.mock.calls.length).toEqual(0);
+        });
+
         it('throws an error if you subscribe when disposed', () => {
             const subscription = new Subscription(
                 '123',

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -1282,13 +1282,17 @@ class Subscription {
         newArgs?: Record<string, unknown>,
         options?:
             | {
-                  isPatch: false;
+                  isPatch?: false;
                   isReplace: true;
               }
             | {
                   isPatch: true;
                   patchArgsDelta: Record<string, unknown>;
-                  isReplace: false;
+                  isReplace?: false;
+              }
+            | {
+                  isPatch?: false;
+                  isReplace?: false;
               },
     ) {
         if (this.isDisposed) {

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -1280,11 +1280,16 @@ class Subscription {
      */
     onModify(
         newArgs?: Record<string, unknown>,
-        options?: {
-            isPatch: boolean;
-            patchArgsDelta: Record<string, unknown>;
-            isReplace: boolean;
-        },
+        options?:
+            | {
+                  isPatch: false;
+                  isReplace: true;
+              }
+            | {
+                  isPatch: true;
+                  patchArgsDelta: Record<string, unknown>;
+                  isReplace: false;
+              },
     ) {
         if (this.isDisposed) {
             throw new Error(


### PR DESCRIPTION
We are getting some data updates after calling remove. After investigation the queue is modify replace, unsubscribe (not force) and because of a bug it is not removing the queue to end up with unsubscribe (force) so that the update is not sent to the subscriber.