### PR TITLE
Fix reconnect on detecting orphans

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### v10.11.2
+
+-  Move reconnect into the library and make sure we clear errors and only trigger if we are really dead
+
 ### v10.11.1
 
 -  Fix a bug causing data updates from a removed subscription

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
-### v10.11.2
+### v11.0.0
 
--  Move reconnect into the library and make sure we clear errors and only trigger if we are really dead
+-  * Breaking * Remove the orphans found event
+-  Move recionnect into the library and make sure we clear errors and only trigger if we are really dead
 
 ### v10.11.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.11.1",
+    "version": "11.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "openapi-clientlib",
-            "version": "10.11.1",
+            "version": "11.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@babel/core": "7.18.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.11.2",
+    "version": "11.0.0",
     "engines": {
         "node": ">=14"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "10.11.1",
+    "version": "10.11.2",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/streaming/connection/constants.ts
+++ b/src/openapi/streaming/connection/constants.ts
@@ -15,10 +15,6 @@ export const EVENT_STREAMING_FAILED = 'streamingFailed' as const;
  */
 export const EVENT_DISCONNECT_REQUESTED =
     'streamingDisconnectRequested' as const;
-/**
- * Event that occurs when multiple orphans are detected in a short period.
- */
-export const EVENT_MULTIPLE_ORPHANS_FOUND = 'multipleOrphansFound' as const;
 
 /**
  * Event that occurs when probe message is received.

--- a/src/openapi/streaming/orphan-finder.ts
+++ b/src/openapi/streaming/orphan-finder.ts
@@ -8,7 +8,7 @@ const MAX_UPDATE_DELAY = 5000;
 // It is rare that orphan finder is needed and yet it happens all the time - if the socket gets delayed
 // by 10 seconds then we do not get the update - resubscribing is a big operation and we don't want to be
 // doing it all the time
-export const INACTIVITY_LENIENCY = 15000;
+export const INACTIVITY_LENIENCY = 22000;
 
 interface OnOrphanFoundHandler {
     (subscription: Subscription): void;

--- a/src/openapi/streaming/streaming.spec.ts
+++ b/src/openapi/streaming/streaming.spec.ts
@@ -1112,11 +1112,7 @@ describe('openapi Streaming', () => {
             // @ts-expect-error using mocked subscription
             streaming.subscriptions.push(subscription2);
 
-            const mockEventListener = jest.fn();
-            streaming.on(
-                streaming.EVENT_MULTIPLE_ORPHANS_FOUND,
-                mockEventListener,
-            );
+            jest.spyOn(streaming, 'reconnect');
 
             // @ts-expect-error using mocked subscription
             streaming.orphanFinder.onOrphanFound(subscription1);
@@ -1129,7 +1125,10 @@ describe('openapi Streaming', () => {
             streaming.orphanFinder.onOrphanFound(subscription2);
             tick(16);
 
-            expect(mockEventListener).toHaveBeenCalledTimes(1);
+            expect(streaming.reconnect).toHaveBeenCalledTimes(1);
+
+            // @ts-expect-error orphanEvents is private
+            expect(streaming.orphanEvents.length).toEqual(0);
         });
 
         it('does not fire an error when multiple service paths orphan >70s apart', () => {
@@ -1147,11 +1146,7 @@ describe('openapi Streaming', () => {
             // @ts-expect-error using mocked subscription
             streaming.subscriptions.push(subscription2);
 
-            const mockEventListener = jest.fn();
-            streaming.on(
-                streaming.EVENT_MULTIPLE_ORPHANS_FOUND,
-                mockEventListener,
-            );
+            jest.spyOn(streaming, 'reconnect');
 
             // @ts-expect-error using mocked subscription
             streaming.orphanFinder.onOrphanFound(subscription1);
@@ -1164,7 +1159,7 @@ describe('openapi Streaming', () => {
             streaming.orphanFinder.onOrphanFound(subscription2);
             tick(16);
 
-            expect(mockEventListener).not.toHaveBeenCalled();
+            expect(streaming.reconnect).not.toHaveBeenCalled();
         });
 
         it('does not fire an error when multiple service paths orphan <20s apart', () => {
@@ -1182,11 +1177,7 @@ describe('openapi Streaming', () => {
             // @ts-expect-error using mocked subscription
             streaming.subscriptions.push(subscription2);
 
-            const mockEventListener = jest.fn();
-            streaming.on(
-                streaming.EVENT_MULTIPLE_ORPHANS_FOUND,
-                mockEventListener,
-            );
+            jest.spyOn(streaming, 'reconnect');
 
             // @ts-expect-error using mocked subscription
             streaming.orphanFinder.onOrphanFound(subscription1);
@@ -1199,7 +1190,7 @@ describe('openapi Streaming', () => {
             streaming.orphanFinder.onOrphanFound(subscription2);
             tick(16);
 
-            expect(mockEventListener).not.toHaveBeenCalled();
+            expect(streaming.reconnect).not.toHaveBeenCalled();
         });
 
         it('passes on subscribe calls', () => {

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -1295,6 +1295,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
         }
 
         this.orphanFinder.stop();
+        this.orphanEvents = [];
 
         for (let i = 0; i < this.subscriptions.length; i++) {
             const subscription = this.subscriptions[i];
@@ -1324,6 +1325,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
         this.disposed = true;
 
         this.orphanFinder.stop();
+        this.orphanEvents = [];
 
         for (let i = 0; i < this.subscriptions.length; i++) {
             const subscription = this.subscriptions[i];
@@ -1351,6 +1353,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
         this.isReset = true;
 
         this.orphanFinder.stop();
+        this.orphanEvents = [];
 
         if (this.reconnecting) {
             clearTimeout(this.reconnectTimer);

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -439,6 +439,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
 
                 this.shouldSubscribeBeforeStreamingSetup = false;
                 this.orphanFinder.stop();
+                this.orphanEvents = [];
 
                 if (this.isReset) {
                     this.init();
@@ -476,6 +477,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
                 this.updateConnectionQuery();
 
                 this.orphanFinder.stop();
+                this.orphanEvents = [];
                 break;
 
             case this.CONNECTION_STATE_CONNECTED:
@@ -935,8 +937,6 @@ class Streaming extends MicroEmitter<EmittedEvents> {
                         heartBeatLog: this.heartBeatLog,
                     },
                 );
-                // reset orphan events so we wait until the new connection is established before reconnecting
-                this.orphanEvents = [];
 
                 // reconnect - we may be disconnected and not know it
                 this.reconnect();
@@ -1281,6 +1281,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
      * It *will not* stop the subscription (see dispose for that). It is useful for testing reconnect logic works or for resetting all subscriptions.
      */
     disconnect() {
+        this.orphanEvents = [];
         this.connection.stop();
     }
 


### PR DESCRIPTION
A year ago we added detection of orphans and then consumers could reconnect on the event.

This pr brings the reconnect directly into the client library and 1) fixes a bug that we aren't resetting orphan data after a reconnect 2) adds a condition to ignore the issue if we received a recent update