### PR TITLE
Fix orphan issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### v11.0.1
+
+-  Do not look for orphans if waiting for the publisher to calm down
+-  Decrease time to cool down from 1 minute to 30 seconds
+
 ### v11.0.0
 
 -  * Breaking * Remove the orphans found event

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-clientlib",
-    "version": "11.0.0",
+    "version": "11.0.1",
     "engines": {
         "node": ">=14"
     },

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -139,7 +139,8 @@ export function __forTestingOnlyResetReferenceId() {
 
 const DEFAULT_REFRESH_RATE_MS = 1000;
 const MIN_REFRESH_RATE_MS = 100;
-const MIN_WAIT_FOR_PUBLISHER_TO_RESPOND_MS = 30000;
+const PUBLISHER_ISSUES_LOOK_FOR_RESETS_IN_MS = 60000;
+const PUBLISHER_ISSUES_COOLDOWN_MS = 30000;
 
 const FORMAT_PROTOBUF = 'application/x-protobuf';
 const FORMAT_JSON = 'application/json';
@@ -301,14 +302,18 @@ class Subscription {
             if (
                 !this.waitForPublisherToRespondTimer &&
                 this.resetTimeStamps[2] - this.resetTimeStamps[0] <
-                    MIN_WAIT_FOR_PUBLISHER_TO_RESPOND_MS
+                    PUBLISHER_ISSUES_LOOK_FOR_RESETS_IN_MS
             ) {
                 // 3 reset within 1 minute so wait for 30 seconds for publisher to respond
                 // this can also happen due to errors client side and in this case
                 // this code prevents us from spamming the servers
                 log.warn(
                     LOG_AREA,
-                    '3 resets occurred within 1 minute - cooling down subscription for 30 seconds',
+                    `3 resets occurred within ${
+                        PUBLISHER_ISSUES_LOOK_FOR_RESETS_IN_MS / 1000
+                    }s - cooling down subscription for ${
+                        PUBLISHER_ISSUES_COOLDOWN_MS / 1000
+                    }s`,
                     {
                         url: this.url,
                         servicePath: this.servicePath,
@@ -334,7 +339,7 @@ class Subscription {
                     ) {
                         this.unsubscribeAndSubscribe();
                     }
-                }, MIN_WAIT_FOR_PUBLISHER_TO_RESPOND_MS);
+                }, PUBLISHER_ISSUES_COOLDOWN_MS);
 
                 return true;
             } else if (this.waitForPublisherToRespondTimer) {

--- a/src/openapi/streaming/subscription.ts
+++ b/src/openapi/streaming/subscription.ts
@@ -1490,7 +1490,8 @@ class Subscription {
             this.currentState === this.STATE_UNSUBSCRIBE_REQUESTED ||
             this.currentState === this.STATE_SUBSCRIBE_REQUESTED ||
             this.currentState === this.STATE_REPLACE_REQUESTED ||
-            // we are waiting a minute as we got so many resets - the subscription will be reset eventually
+            // This means the subscription has been reset and will not get updates - we are waiting
+            // and will eventually reset it, so we should ignore it in the orphan finder.
             this.waitForPublisherToRespondTimer
         ) {
             return Infinity;


### PR DESCRIPTION
Came from investigating why we have to many orphan logs. In conseqence this shouldn't have much of a end user effect, except it might be longer before the subscription is reset (because the orphan finder won't reset it)