### PR TITLE
Retry initial connection under experimental flag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+### v11.1.0
+
+-  Add experimentalRetryConnectCount which for signalr core will retry after an initial connection error before falling back (e.g. to long polling)
+-  Always subscribe immediately, even after the initial streaming connection is connected or it initially fails
+-  change the connection status to Reconnecting when the initial connect of signalr-streaming fails, to allow the consumer to detect issues
+
 ### v11.0.2
 
 - Do not warn of missing content type if there is no content
@@ -6,7 +12,7 @@
 
 -  Do not look for orphans if waiting for the publisher to calm down
 -  Decrease time to cool down from 1 minute to 30 seconds
-- Make isNetworkError always be a boolean
+-  Make isNetworkError always be a boolean
 
 ### v11.0.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "openapi-clientlib",
-    "version": "11.0.2",
+    "version": "11.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "openapi-clientlib",
-            "version": "11.0.2",
+            "version": "11.1.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@babel/core": "7.19.6",

--- a/src/openapi/streaming/connection/connection.ts
+++ b/src/openapi/streaming/connection/connection.ts
@@ -138,10 +138,15 @@ class Connection {
     };
 
     private onTransportFail = (error?: Record<string, unknown>) => {
-        log.info(LOG_AREA, 'Transport failed', {
-            error,
-            ...this.getLogDetails(),
-        });
+        log.info(
+            LOG_AREA,
+            'Transport failed',
+            {
+                error,
+                ...this.getLogDetails(),
+            },
+            { persist: true },
+        );
 
         // Try to create next possible transport.
         this.transport = this.createTransport(this.baseUrl);

--- a/src/openapi/streaming/connection/transport/signalr-core-transport.spec.ts
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.spec.ts
@@ -3,6 +3,7 @@ import {
     uninstallClock,
     tick,
     getResolvablePromise,
+    setTimeout,
 } from '../../../../test/utils';
 import mockMathRandom from '../../../../test/mocks/math-random';
 import mockAuthProvider from '../../../../test/mocks/authProvider';
@@ -57,6 +58,12 @@ describe('openapi SignalR core Transport', () => {
         build() {
             return mockHubConnection;
         }
+    }
+
+    function wait() {
+        return new Promise<void>((resolve) => {
+            setTimeout(resolve);
+        });
     }
 
     function MockJsonHubProtocol() {
@@ -144,7 +151,7 @@ describe('openapi SignalR core Transport', () => {
             tokenFactory();
             setTimeout(() => {
                 reconnectedCallbacks.forEach((callback) => callback());
-            }, 0);
+            });
         };
 
         mockReconnecting = () => {
@@ -181,7 +188,6 @@ describe('openapi SignalR core Transport', () => {
     });
 
     describe('start', () => {
-        let startPromise: Promise<any>;
         let transport: any;
 
         beforeEach(() => {
@@ -196,10 +202,11 @@ describe('openapi SignalR core Transport', () => {
                 CONTEXT_ID,
                 authprovider.getExpiry(),
             );
-            startPromise = transport.start({}, spyOnStartCallback);
         });
 
-        it('should create message stream and call state change handler upon transport start invocation', (done) => {
+        it('should create message stream and call state change handler upon transport start invocation', async () => {
+            const startPromise = transport.start({}, spyOnStartCallback);
+
             expect(spyOnStartCallback).not.toBeCalled();
             expect(spyOnStateChangedCallback).toHaveBeenNthCalledWith(
                 1,
@@ -209,19 +216,19 @@ describe('openapi SignalR core Transport', () => {
             // resolve handshake request
             mockStart.resolve();
 
-            startPromise.then(() => {
-                expect(spyOnStateChangedCallback).toHaveBeenNthCalledWith(
-                    2,
-                    constants.CONNECTION_STATE_CONNECTED,
-                );
-                expect(spyOnStartCallback).toBeCalledTimes(1);
-                expect(spyOnMessageStream).toBeCalledTimes(1);
+            await startPromise;
 
-                done();
-            });
+            expect(spyOnStateChangedCallback).toHaveBeenNthCalledWith(
+                2,
+                constants.CONNECTION_STATE_CONNECTED,
+            );
+            expect(spyOnStartCallback).toBeCalledTimes(1);
+            expect(spyOnMessageStream).toBeCalledTimes(1);
         });
 
-        it('should renew session with new token if token was updated while response was in flight', (done) => {
+        it('should renew session with new token if token was updated while response was in flight', async () => {
+            const startPromise = transport.start({}, spyOnStartCallback);
+
             expect(spyOnStateChangedCallback).toHaveBeenNthCalledWith(
                 1,
                 constants.CONNECTION_STATE_CONNECTING,
@@ -233,18 +240,19 @@ describe('openapi SignalR core Transport', () => {
             // resolve handshake request
             mockStart.resolve();
 
-            startPromise.then(() => {
-                expect(spyOnStateChangedCallback).toHaveBeenNthCalledWith(
-                    2,
-                    constants.CONNECTION_STATE_CONNECTED,
-                );
+            await startPromise;
 
-                expect(mockRenewToken).toBeDefined();
-                done();
-            });
+            expect(spyOnStateChangedCallback).toHaveBeenNthCalledWith(
+                2,
+                constants.CONNECTION_STATE_CONNECTED,
+            );
+
+            expect(mockRenewToken).toBeDefined();
         });
 
-        it('should call transport fail callback if handshake request fails with valid status code', (done) => {
+        it('should call transport fail callback if handshake request fails with valid status code', async () => {
+            const startPromise = transport.start({}, spyOnStartCallback);
+
             expect(spyOnStateChangedCallback).toHaveBeenCalledWith(
                 constants.CONNECTION_STATE_CONNECTING,
             );
@@ -255,34 +263,170 @@ describe('openapi SignalR core Transport', () => {
             error.statusCode = 500;
             mockStart.reject(error);
 
-            startPromise.then(() => {
-                expect(spyOnStartCallback).not.toBeCalled();
-                expect(spyOnStateChangedCallback).toBeCalledTimes(1);
-                expect(spyOnTransportFailedCallback).toBeCalledTimes(1);
-                done();
-            });
+            await startPromise;
+
+            expect(spyOnStartCallback).not.toBeCalled();
+            // connecting and then reconnecting
+            expect(spyOnStateChangedCallback.mock.calls).toMatchInlineSnapshot(`
+                Array [
+                  Array [
+                    4,
+                  ],
+                  Array [
+                    16,
+                  ],
+                ]
+            `);
+            expect(spyOnTransportFailedCallback).toBeCalledTimes(1);
         });
 
-        it('should trigger disconnect if error is received while starting message streaming', (done) => {
+        it('should retry if experimentalRetryConnectCount is set and then call transport fail callback if handshake request fails', async () => {
+            const startPromise = transport.start(
+                { experimentalRetryConnectCount: 2 },
+                spyOnStartCallback,
+            );
+
+            expect(spyOnStateChangedCallback).toHaveBeenCalledWith(
+                constants.CONNECTION_STATE_CONNECTING,
+            );
+
+            // fail handshake request with valid server error
+            const error = new Error('Internal server error');
+            // @ts-ignore
+            error.statusCode = 500;
+            mockStart.reject(error);
+
+            await wait();
+            mockStart.reject(error);
+
+            await wait();
+            mockStart.reject(error);
+
+            expect(spyOnTransportFailedCallback).toBeCalledTimes(0);
+
+            await wait();
+            mockStart.reject(error);
+
+            await startPromise;
+
+            expect(spyOnStartCallback).not.toBeCalled();
+            // connecting and then reconnecting
+            expect(spyOnStateChangedCallback.mock.calls).toMatchInlineSnapshot(`
+                Array [
+                  Array [
+                    4,
+                  ],
+                  Array [
+                    4,
+                  ],
+                  Array [
+                    4,
+                  ],
+                  Array [
+                    32,
+                  ],
+                  Array [
+                    32,
+                  ],
+                  Array [
+                    32,
+                  ],
+                  Array [
+                    16,
+                  ],
+                  Array [
+                    32,
+                  ],
+                  Array [
+                    32,
+                  ],
+                  Array [
+                    32,
+                  ],
+                ]
+            `);
+            expect(spyOnTransportFailedCallback).toBeCalledTimes(1);
+        });
+
+        it('should retry if experimentalRetryConnectCount is set and eventually succeed', async () => {
+            const startPromise = transport.start(
+                { experimentalRetryConnectCount: 2 },
+                spyOnStartCallback,
+            );
+
+            expect(spyOnStateChangedCallback).toHaveBeenCalledWith(
+                constants.CONNECTION_STATE_CONNECTING,
+            );
+
+            // fail handshake request with valid server error
+            const error = new Error('Internal server error');
+            // @ts-ignore
+            error.statusCode = 500;
+            mockStart.reject(error);
+
+            await wait();
+            mockStart.reject(error);
+
+            await wait();
+            mockStart.resolve();
+
+            await startPromise;
+
+            expect(spyOnStartCallback).toBeCalledTimes(1);
+            // connecting and then reconnecting and finally connected
+            expect(spyOnStateChangedCallback.mock.calls).toMatchInlineSnapshot(`
+                Array [
+                  Array [
+                    4,
+                  ],
+                  Array [
+                    4,
+                  ],
+                  Array [
+                    4,
+                  ],
+                  Array [
+                    32,
+                  ],
+                  Array [
+                    32,
+                  ],
+                  Array [
+                    32,
+                  ],
+                  Array [
+                    8,
+                  ],
+                ]
+            `);
+            expect(spyOnTransportFailedCallback).toBeCalledTimes(0);
+        });
+
+        it('should trigger disconnect if error is received while starting message streaming', async () => {
+            const startPromise = transport.start({}, spyOnStartCallback);
+
             // resolve handshake request
             mockStart.resolve();
 
-            startPromise
-                .then(() => {
-                    subscribeErrorHandler(new Error('Streaming error'));
-                    mockCloseConnection.resolve();
-                    return mockCloseConnection.promise;
-                })
-                .then(() => {
-                    tick(10);
+            await startPromise;
 
-                    expect(spyOnTransportFailedCallback).toBeCalledTimes(0);
-                    expect(spyOnStateChangedCallback).toHaveBeenNthCalledWith(
-                        3,
-                        constants.CONNECTION_STATE_DISCONNECTED,
-                    );
-                    done();
-                });
+            subscribeErrorHandler(new Error('Streaming error'));
+            mockCloseConnection.resolve();
+            await mockCloseConnection.promise;
+
+            tick(10);
+
+            expect(spyOnTransportFailedCallback).toBeCalledTimes(0);
+            expect(spyOnStateChangedCallback.mock.calls).toMatchInlineSnapshot(`
+                Array [
+                  Array [
+                    4,
+                  ],
+                  Array [
+                    8,
+                  ],
+                ]
+            `);
         });
     });
 

--- a/src/openapi/streaming/connection/transport/signalr-core-transport.spec.ts
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.spec.ts
@@ -3,7 +3,7 @@ import {
     uninstallClock,
     tick,
     getResolvablePromise,
-    setTimeout,
+    wait,
 } from '../../../../test/utils';
 import mockMathRandom from '../../../../test/mocks/math-random';
 import mockAuthProvider from '../../../../test/mocks/authProvider';
@@ -58,12 +58,6 @@ describe('openapi SignalR core Transport', () => {
         build() {
             return mockHubConnection;
         }
-    }
-
-    function wait() {
-        return new Promise<void>((resolve) => {
-            setTimeout(resolve);
-        });
     }
 
     function MockJsonHubProtocol() {
@@ -310,7 +304,7 @@ describe('openapi SignalR core Transport', () => {
             await startPromise;
 
             expect(spyOnStartCallback).not.toBeCalled();
-            // connecting and then reconnecting
+            // connecting x3 and then reconnecting
             expect(spyOnStateChangedCallback.mock.calls).toMatchInlineSnapshot(`
                 Array [
                   Array [
@@ -323,25 +317,7 @@ describe('openapi SignalR core Transport', () => {
                     4,
                   ],
                   Array [
-                    32,
-                  ],
-                  Array [
-                    32,
-                  ],
-                  Array [
-                    32,
-                  ],
-                  Array [
                     16,
-                  ],
-                  Array [
-                    32,
-                  ],
-                  Array [
-                    32,
-                  ],
-                  Array [
-                    32,
                   ],
                 ]
             `);
@@ -373,7 +349,7 @@ describe('openapi SignalR core Transport', () => {
             await startPromise;
 
             expect(spyOnStartCallback).toBeCalledTimes(1);
-            // connecting and then reconnecting and finally connected
+            // connecting x3 and then connected
             expect(spyOnStateChangedCallback.mock.calls).toMatchInlineSnapshot(`
                 Array [
                   Array [
@@ -384,15 +360,6 @@ describe('openapi SignalR core Transport', () => {
                   ],
                   Array [
                     4,
-                  ],
-                  Array [
-                    32,
-                  ],
-                  Array [
-                    32,
-                  ],
-                  Array [
-                    32,
                   ],
                   Array [
                     8,
@@ -414,6 +381,8 @@ describe('openapi SignalR core Transport', () => {
             mockCloseConnection.resolve();
             await mockCloseConnection.promise;
 
+            await wait();
+
             tick(10);
 
             expect(spyOnTransportFailedCallback).toBeCalledTimes(0);
@@ -424,6 +393,9 @@ describe('openapi SignalR core Transport', () => {
                   ],
                   Array [
                     8,
+                  ],
+                  Array [
+                    32,
                   ],
                 ]
             `);

--- a/src/openapi/streaming/connection/transport/signalr-core-transport.ts
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.ts
@@ -347,27 +347,29 @@ class SignalrCoreTransport implements StreamingTransportInterface {
                 }
             })
             .catch((error) => {
-                log.warn(
+                log.info(
                     LOG_AREA,
-                    'Error occurred while connecting to streaming service',
+                    'Failed to connect to streaming',
                     {
                         error,
                     },
+                    { persist: true },
                 );
-
-                if (experimentalRetryConnectCount === 0) {
-                    this.transportFailCallback({
-                        message: 'error occurred while connecting',
-                    });
-                } else {
+                if (experimentalRetryConnectCount > 0) {
                     this.connection?.stop();
                     this.connection = null;
 
                     this.start(
                         options,
                         onStartCallback,
-                        experimentalRetryConnectCount--,
+                        experimentalRetryConnectCount - 1,
                     );
+                } else {
+                    this.setState(constants.CONNECTION_STATE_RECONNECTING);
+
+                    this.transportFailCallback({
+                        message: 'error occurred while connecting',
+                    });
                 }
             });
     }

--- a/src/openapi/streaming/connection/transport/signalr-core-transport.ts
+++ b/src/openapi/streaming/connection/transport/signalr-core-transport.ts
@@ -65,11 +65,14 @@ class SignalrCoreTransport implements StreamingTransportInterface {
     unauthorizedCallback: (url: string) => void = NOOP;
     setConnectionSlowCallback = NOOP;
     subscriptionResetCallback = NOOP;
-    transportFailCallback;
+    transportFailCallback: (error: Record<string, unknown>) => void;
 
     utf8Decoder!: TextDecoder;
 
-    constructor(baseUrl: string, transportFailCallback = NOOP) {
+    constructor(
+        baseUrl: string,
+        transportFailCallback: (error?: Record<string, unknown>) => void = NOOP,
+    ) {
         this.baseUrl = baseUrl;
         // callbacks
         this.transportFailCallback = transportFailCallback;
@@ -85,7 +88,9 @@ class SignalrCoreTransport implements StreamingTransportInterface {
                 },
             );
 
-            transportFailCallback();
+            transportFailCallback({
+                message: 'Failed to initialize text decoder',
+            });
         }
     }
 
@@ -245,7 +250,12 @@ class SignalrCoreTransport implements StreamingTransportInterface {
         };
     }
 
-    start(options: StreamingTransportOptions, onStartCallback?: () => void) {
+    start(
+        options: StreamingTransportOptions,
+        onStartCallback?: () => void,
+        experimentalRetryConnectCount = options.experimentalRetryConnectCount ??
+            0,
+    ) {
         if (this.connection) {
             log.warn(
                 LOG_AREA,
@@ -280,7 +290,9 @@ class SignalrCoreTransport implements StreamingTransportInterface {
                 error,
             });
 
-            this.transportFailCallback();
+            this.transportFailCallback({
+                message: "Couldn't initialize the connection",
+            });
             return;
         }
 
@@ -343,7 +355,20 @@ class SignalrCoreTransport implements StreamingTransportInterface {
                     },
                 );
 
-                this.transportFailCallback();
+                if (experimentalRetryConnectCount === 0) {
+                    this.transportFailCallback({
+                        message: 'error occurred while connecting',
+                    });
+                } else {
+                    this.connection?.stop();
+                    this.connection = null;
+
+                    this.start(
+                        options,
+                        onStartCallback,
+                        experimentalRetryConnectCount--,
+                    );
+                }
             });
     }
 
@@ -375,7 +400,7 @@ class SignalrCoreTransport implements StreamingTransportInterface {
             const closePromise =
                 this.connection &&
                 this.connection.state === HubConnectionState.Connected
-                    ? // @ts-expect-error cancelCallback is no included in the IStreamResult but according to implementation it exists
+                    ? // @ts-expect-error cancelCallback is not included in the IStreamResult but according to implementation it exists
                       this.messageStream.cancelCallback()
                     : Promise.resolve();
             return closePromise
@@ -444,7 +469,9 @@ class SignalrCoreTransport implements StreamingTransportInterface {
         this.hasTransportError = false;
 
         if (shouldFallbackToOtherTransport) {
-            this.transportFailCallback();
+            this.transportFailCallback({
+                message: 'Permanent transport error',
+            });
             return;
         }
 

--- a/src/openapi/streaming/connection/transport/websocket-transport.spec.ts
+++ b/src/openapi/streaming/connection/transport/websocket-transport.spec.ts
@@ -2,7 +2,7 @@ import {
     installClock,
     uninstallClock,
     tick,
-    setTimeout,
+    wait,
 } from '../../../../test/utils';
 import mockMathRandom from '../../../../test/mocks/math-random';
 import mockFetch from '../../../../test/mocks/fetch';
@@ -17,12 +17,6 @@ import type WebsocketTransport from './websocket-transport';
 const CONTEXT_ID = '0000000000';
 const AUTH_TOKEN = 'TOKEN';
 const BASE_URL = 'testUrl';
-
-function wait() {
-    return new Promise<void>((resolve) => {
-        setTimeout(resolve);
-    });
-}
 
 describe('openapi WebSocket Transport', () => {
     let fetchMock: ReturnType<typeof mockFetch>;

--- a/src/openapi/streaming/streaming-websocket.spec.ts
+++ b/src/openapi/streaming/streaming-websocket.spec.ts
@@ -207,8 +207,8 @@ describe('openapi Streaming', () => {
 
         it('tells subscriptions it is not connected when they are created before connect', () => {
             givenStreaming();
-            // we test the property because we get the subscription after unavailable has been called, and before we spy on the method
-            expect(subscription.connectionAvailable).toEqual(true);
+            // the createSubscription calls subscribe, then makes it unavailable, then we mock it afterwards
+            expect(subscription.connectionAvailable).toEqual(false);
         });
         it('tells subscriptions it is connected when they are created after connect', () => {
             givenStreaming();

--- a/src/openapi/streaming/streaming.spec.ts
+++ b/src/openapi/streaming/streaming.spec.ts
@@ -335,8 +335,9 @@ describe('openapi Streaming', () => {
 
         it('tells subscriptions it is not connected when they are created before connect', () => {
             givenStreaming();
-            // we test the property because we get the subscription after unavailable has been called, and before we spy on the method
-            expect(subscription.connectionAvailable).toEqual(true);
+
+            // the createSubscription calls subscribe, then makes it unavailable, then we mock it afterwards
+            expect(subscription.connectionAvailable).toEqual(false);
         });
 
         it('tells subscriptions it is connected when they are created after connect', () => {
@@ -1305,21 +1306,18 @@ describe('openapi Streaming', () => {
             );
 
             // streaming Initializing state
-            expect(streaming.shouldSubscribeBeforeStreamingSetup).toBe(true);
             streaming.createSubscription('root', '/test/test', {});
-            expect(streaming.subscriptions[0].connectionAvailable).toBe(true);
+            expect(streaming.subscriptions[0].connectionAvailable).toBe(false);
 
             // streaming Connected state
             expect(streaming.subscriptions[0].latestActivity).toBeFalsy();
             stateChangedCallback({ newState: 1 /* Connected */ });
             expect(streaming.subscriptions[0].latestActivity).toBeTruthy();
-            expect(streaming.shouldSubscribeBeforeStreamingSetup).toBe(false);
             streaming.createSubscription('root', '/test/test', {});
             expect(streaming.subscriptions[1].connectionAvailable).toBe(true);
 
             // // streaming Disconnected state
             stateChangedCallback({ newState: 4 /* Disconnected */ });
-            expect(streaming.shouldSubscribeBeforeStreamingSetup).toBe(false);
             streaming.createSubscription('root', '/test/test', {});
             expect(streaming.subscriptions[2].connectionAvailable).toBe(false);
         });

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -168,7 +168,6 @@ class Streaming extends MicroEmitter<EmittedEvents> {
     reconnectTimer?: number;
     disposed = false;
     private heartBeatLog: Array<[number, ReadonlyArray<string>]> = [];
-    shouldSubscribeBeforeStreamingSetup: boolean;
 
     /**
      * @param transport - The transport to use for subscribing/unsubscribing.
@@ -199,8 +198,6 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             this.subscriptions,
             this.onOrphanFound.bind(this),
         );
-
-        this.shouldSubscribeBeforeStreamingSetup = true;
 
         this.init();
     }
@@ -312,7 +309,11 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             log.warn(
                 LOG_AREA,
                 'Only call connect on a disconnected streaming connection',
-                new Error(),
+                {
+                    connectionState: this.connectionState,
+                    // for stack
+                    error: new Error(),
+                },
             );
             return;
         }
@@ -401,7 +402,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
         const connectionTransport = this.getActiveTransportName();
 
         if (nextState === this.connectionState) {
-            log.warn(LOG_AREA, 'Trying to set same state as current one', {
+            log.debug(LOG_AREA, 'Trying to set same state as current one', {
                 connectionState:
                     this.connectionState &&
                     this.READABLE_CONNECTION_STATE_MAP[this.connectionState],
@@ -439,7 +440,6 @@ class Streaming extends MicroEmitter<EmittedEvents> {
                     { persist: true },
                 );
 
-                this.shouldSubscribeBeforeStreamingSetup = false;
                 this.orphanFinder.stop();
                 this.orphanEvents = [];
 
@@ -469,7 +469,6 @@ class Streaming extends MicroEmitter<EmittedEvents> {
                     { persist: true },
                 );
 
-                this.shouldSubscribeBeforeStreamingSetup = false;
                 // tell all subscriptions not to do anything
                 // as we may have lost internet and the subscriptions may not be reset
                 for (let i = 0; i < this.subscriptions.length; i++) {
@@ -494,17 +493,11 @@ class Streaming extends MicroEmitter<EmittedEvents> {
 
                 for (let i = 0; i < this.subscriptions.length; i++) {
                     this.subscriptions[i].onConnectionAvailable();
-                    if (this.shouldSubscribeBeforeStreamingSetup) {
-                        // trigger onActivity of subscribed subscriptions before streaming setup to avoid reset by orphan finder
-                        this.subscriptions[i].onActivity();
-                    }
+                    // trigger onActivity of subscribed subscriptions before streaming setup to avoid reset by orphan finder
+                    // in case streaming connect took some time
+                    this.subscriptions[i].onActivity();
                 }
-                this.shouldSubscribeBeforeStreamingSetup = false;
                 this.orphanFinder.start();
-                break;
-
-            case this.CONNECTION_STATE_FAILED:
-                this.shouldSubscribeBeforeStreamingSetup = false;
                 break;
         }
     }
@@ -1183,15 +1176,14 @@ class Streaming extends MicroEmitter<EmittedEvents> {
 
         this.subscriptions.push(subscription);
 
-        // set the subscription to connection unavailable, the subscription will then subscribe when the connection becomes available.
-        // if shouldSubscribeBeforeStreamingSetup is set it will subscribe immediately
-        if (
-            !this.shouldSubscribeBeforeStreamingSetup &&
-            this.connectionState !== this.CONNECTION_STATE_CONNECTED
-        ) {
+        subscription.onSubscribe();
+
+        // The above will immediately send a subscribe request, but now if the connection is not connected, we
+        // set the subscription to unavailable. This stops the subscription retrying etc. when streaming is not
+        // available which can lead to alot of subscription requests
+        if (this.connectionState !== this.CONNECTION_STATE_CONNECTED) {
             subscription.onConnectionUnavailable();
         }
-        subscription.onSubscribe();
 
         return subscription;
     }

--- a/src/openapi/streaming/streaming.ts
+++ b/src/openapi/streaming/streaming.ts
@@ -218,6 +218,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             parserEngines,
             parsers,
             shouldLoopTransports,
+            experimentalRetryConnectCount,
         } = options;
 
         this.connectionOptions = {
@@ -229,6 +230,7 @@ class Streaming extends MicroEmitter<EmittedEvents> {
             // This protocol is used to serialize the message envelope rather than the payload
             messageSerializationProtocol,
             shouldLoopTransports,
+            experimentalRetryConnectCount,
         };
 
         if (typeof connectRetryDelay === 'number') {

--- a/src/openapi/streaming/subscription.spec.ts
+++ b/src/openapi/streaming/subscription.spec.ts
@@ -4,6 +4,7 @@ import {
     installClock,
     uninstallClock,
     tick,
+    wait,
 } from '../../test/utils';
 import mockTransport from '../../test/mocks/transport';
 import * as mockProtoPrice from '../../test/mocks/proto-price';
@@ -20,12 +21,6 @@ ParserFacade.addEngines({
 ParserFacade.addParsers({
     'application/x-protobuf': ParserProtobuf,
 });
-
-function wait() {
-    return new Promise<void>((resolve) => {
-        setTimeout(resolve);
-    });
-}
 
 describe('openapi StreamingSubscription', () => {
     let transport: any;

--- a/src/openapi/streaming/types.ts
+++ b/src/openapi/streaming/types.ts
@@ -20,6 +20,7 @@ export interface ConnectionOptions {
     messageSerializationProtocol?: IHubProtocol;
     isWebsocketStreamingHeartBeatEnabled?: boolean;
     shouldLoopTransports?: boolean;
+    experimentalRetryConnectCount?: number;
 }
 
 export type ConnectionState =
@@ -140,4 +141,8 @@ export interface StreamingConfigurableOptions {
      * Should the transports be retried in a loop
      */
     shouldLoopTransports?: boolean;
+    /**
+     * The number of times to retry the initial connect
+     */
+    experimentalRetryConnectCount?: number;
 }

--- a/src/openapi/streaming/types.ts
+++ b/src/openapi/streaming/types.ts
@@ -133,11 +133,6 @@ export interface StreamingConfigurableOptions {
      */
     isWebsocketStreamingHeartBeatEnabled?: boolean;
     /**
-     *  Flag to control whether we should subscribe before streaming setup during initial subscribe
-     *  This happens only for the first streaming connection setup after that we turn this off
-     */
-    shouldSubscribeBeforeStreamingSetup?: boolean;
-    /**
      * Should the transports be retried in a loop
      */
     shouldLoopTransports?: boolean;

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -53,6 +53,12 @@ const getResolvablePromise = () => {
     };
 };
 
+function wait() {
+    return new Promise<void>((resolve) => {
+        setTimeout(resolve);
+    });
+}
+
 export {
     tick,
     setTimeout,
@@ -61,4 +67,5 @@ export {
     uninstallClock,
     waterfallTimeout,
     getResolvablePromise,
+    wait,
 };


### PR DESCRIPTION
Firstly, some streaming connections are falling back to long polling, so I added a option to allow the initial connect to retry before falling back to long polling.

Then I looked at why the initial connection being blocked did not result in detection of lack of a network connection - it is because no reconnecting event is being sent. Then I found that we were not subscribing if the subscribe request came in after streaming had failed, because by then we set the option to subscribe before setup to false, so I changed that around to take a different approach.